### PR TITLE
Complete overhaul of the solar scaling

### DIFF
--- a/basta/bastamain.py
+++ b/basta/bastamain.py
@@ -406,7 +406,6 @@ def BASTA(
         "asciioutput",
         "asciioutput_dist",
         "distanceparams",
-        "dnu_scales",
         "dnufit",
         "dnufrac",
         "erroutput",


### PR DESCRIPTION
In the current version, the dnu scaling is only correctly applied for dnu's in `outparams`. In other words, if e.g. `dnufit` is only in `fitparams` but not outputted, the value will *not* be scaled to the grid value. As a result hereof, the fitting results (best-fitting-models, posteriors, key stats, etc.) are dependent on whether dnu is in the output or not.

This issue has been fixed. Additionally, the entire routine to perform the solar scaling has been restructured to improve readability. 