### PR TITLE
Intpol bayweights along tracks fix

### DIFF
--- a/basta/interpolation_across.py
+++ b/basta/interpolation_across.py
@@ -461,8 +461,6 @@ def _interpolate_across(
                     outfile[keypath] = 1.0
                 elif key == along_var:
                     outfile[keypath] = newbase[:, -1]
-                elif key == dname:
-                    outfile[keypath] = ih.bay_weights(newbase[:, -1])
                 elif "name" in key:
                     outfile[keypath] = len(newbase[:, -1]) * [b"interpolated-entry"]
                 elif ("osc" in key) or (key in const_vars):
@@ -539,6 +537,12 @@ def _interpolate_across(
                     outfile[keypath]
                 except:
                     outfile[keypath] = np.ones(len(newbase[:, -1])) * const_vars[par]
+
+            # Bayesian weight along track
+            par = "massfin" if dname == "dmass" else "age"
+            parpath = os.path.join(libname, par)
+            keypath = os.path.join(libname, dname)
+            outfile[keypath] = ih.bay_weights(outfile[parpath])
 
             if debug:
                 debugnum = str(int(newnum + tracknum)).zfill(numfmt)

--- a/basta/interpolation_along.py
+++ b/basta/interpolation_along.py
@@ -409,8 +409,6 @@ def _interpolate_along(
                     keypath = os.path.join(libitem.name, key)
                     if "_weight" in key:
                         newparam = libitem[key][()]
-                    elif key == dname:
-                        newparam = ih.bay_weights(intpolmesh)
                     elif "name" in key:
                         newparam = len(intpolmesh) * [b"interpolated-entry"]
                     elif "osc" in key:
@@ -432,6 +430,12 @@ def _interpolate_along(
                     # Storage for plotting the Kiel diagram
                     if key in ["Teff", "logg", "age", "massfin"]:
                         tmpparam[key] = newparam
+
+                # Bayesian weight along track
+                par = "massfin" if dname == "dmass" else "age"
+                parpath = os.path.join(libname, par)
+                keypath = os.path.join(libname, dname)
+                outfile[keypath] = ih.bay_weights(outfile[parpath])
 
                 #
                 # *** BLOCK 4: Interpolate in frequencies ***

--- a/basta/interpolation_along.py
+++ b/basta/interpolation_along.py
@@ -433,8 +433,10 @@ def _interpolate_along(
 
                 # Bayesian weight along track
                 par = "massfin" if dname == "dmass" else "age"
-                parpath = os.path.join(libname, par)
-                keypath = os.path.join(libname, dname)
+                parpath = os.path.join(libitem.name, par)
+                keypath = os.path.join(libitem.name, dname)
+                if overwrite:
+                    del outfile[keypath]
                 outfile[keypath] = ih.bay_weights(outfile[parpath])
 
                 #

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -269,11 +269,10 @@ def interpolate_grid(
     # Nicknames for resolution in frequency
     freqres = ["freq", "freqs", "frequency", "frequencies", "osc"]
     intpol_freqs = False
-    dname = "dage" if "grid" in basepath else "dmass"
 
     # Check that necessary parameters are in intpolparams
     # First is standard for tracks/isochrones, mostly for Kiel-diagram
-    intpolparams += [dname, "Teff", "logg", "massini", "age", "FeH"]
+    intpolparams += ["Teff", "logg", "massini", "age", "FeH"]
     if "freqs" in intpolparams:
         intpolparams.remove("freqs")
         intpolparams += ["tau0", "tauhe", "taubcz", "dnufit"]


### PR DESCRIPTION
The Bayesian weights along the tracks/isochrones "dage"/"dmass" were accidentially computed from the chosen base parameter in the interpolation, instead of the age/mass as they should. This update fixes that, by separately computing the "dage"/"dmass" for each track/isochrone after interpolation of all other quantities. This should also ensure they are always computed.