### PR TITLE
3-point ratios

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.2.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
   - id: check-ast
   - id: check-merge-conflict
 - repo: https://github.com/psf/black
-  rev: 21.11b1
+  rev: 22.3.0
   hooks:
   - id: black
     exclude: venv*/|dustmaps/|grids/

--- a/basta/bastamain.py
+++ b/basta/bastamain.py
@@ -247,7 +247,7 @@ def BASTA(
 
     # Prepare asteroseismic quantities if required
     if fitfreqs:
-        (freqxml, glhtxt, correlations, bexp, rt, seisw) = fitfreqs
+        (freqxml, glhtxt, correlations, bexp, rt, seisw, threepoint) = fitfreqs
         if not all(x in freqtypes.alltypes for x in rt):
             raise ValueError("Unrecognized fitting parameters!")
 
@@ -644,6 +644,7 @@ def BASTA(
                             warnings=warn,
                             debug=debug,
                             verbose=verbose,
+                            threepoint=threepoint,
                         )
                         chi2[indd] += chi2_freq
 
@@ -886,6 +887,7 @@ def BASTA(
                 maxjoinkeys,
                 maxjoin,
                 output=ratioplotname,
+                threepoint=threepoint,
             )
     else:
         print(

--- a/basta/fileio.py
+++ b/basta/fileio.py
@@ -1153,6 +1153,7 @@ def read_rt(
     plotratios,
     getfreqcovar=False,
     nottrustedfile=None,
+    threepoint=False,
     verbose=False,
 ):
     """
@@ -1176,6 +1177,9 @@ def read_rt(
     nottrustedfile : str or None.
         Name of file containing the (l, n) values of frequencies to be
         omitted in the fit. If None, no modes will be excluded.
+    threepoint : bool
+        If True, use three point definition of r01 and r10 ratios
+        instead of default five point definition.
     verbose : bool, optional
         If True, extra text will be printed to log (for developers).
 
@@ -1253,7 +1257,7 @@ def read_rt(
         datos010, cov010 = read_r010(filename, rrange, nottrustedfile, verbose=verbose)
         if datos010 is None and "r010" in rt:
             print("* r010 unavailable in xml. Computing it ... ", end="", flush=True)
-            rat, cov010 = su.ratio_and_cov(freq, rtype="R010")
+            rat, cov010 = su.ratio_and_cov(freq, rtype="R010", threepoint=threepoint)
             datos010 = np.zeros((3, len(rat[:, 0])))
             datos010[0, :] = rat[:, 1]
             datos010[1, :] = rat[:, 3]
@@ -1264,7 +1268,7 @@ def read_rt(
         datos02, cov02 = read_r02(filename, rrange, nottrustedfile)
         if datos02 is None and ("r02" in rt or plotratios):
             print("* r02 unavailable in xml. Computing it ... ", end="", flush=True)
-            rat, cov02 = su.ratio_and_cov(freq, rtype="R02")
+            rat, cov02 = su.ratio_and_cov(freq, rtype="R02", threepoint=threepoint)
             datos02 = np.zeros((3, len(rat[:, 0])))
             datos02[0, :] = rat[:, 1]
             datos02[1, :] = rat[:, 3]
@@ -1274,7 +1278,7 @@ def read_rt(
         # R01
         if datos01 is None and ("r01" in rt or plotratios):
             print("* r01 unavailable in xml. Computing it ... ", end="", flush=True)
-            rat, cov01 = su.ratio_and_cov(freq, rtype="R01")
+            rat, cov01 = su.ratio_and_cov(freq, rtype="R01", threepoint=threepoint)
             datos01 = np.zeros((3, len(rat[:, 0])))
             datos01[0, :] = rat[:, 1]
             datos01[1, :] = rat[:, 3]
@@ -1284,7 +1288,7 @@ def read_rt(
         # R10
         if datos10 is None and ("r10" in rt or plotratios):
             print("* r10 unavailable in xml. Computing it ... ", end="", flush=True)
-            rat, cov10 = su.ratio_and_cov(freq, rtype="R10")
+            rat, cov10 = su.ratio_and_cov(freq, rtype="R10", threepoint=threepoint)
             datos10 = np.zeros((3, len(rat[:, 0])))
             datos10[0, :] = rat[:, 1]
             datos10[1, :] = rat[:, 3]
@@ -1294,7 +1298,7 @@ def read_rt(
         # R012
         if datos012 is None and "r012" in rt:
             print("* r012 unavailable in xml. Computing it ... ", end="", flush=True)
-            rat, cov012 = su.ratio_and_cov(freq, rtype="R012")
+            rat, cov012 = su.ratio_and_cov(freq, rtype="R012", threepoint=threepoint)
             datos012 = np.zeros((3, len(rat[:, 0])))
             datos012[0, :] = rat[:, 1]
             datos012[1, :] = rat[:, 3]
@@ -1304,7 +1308,7 @@ def read_rt(
         # R102
         if datos102 is None and "r102" in rt:
             print("* r102 unavailable in xml. Computing it ... ", end="", flush=True)
-            rat, cov102 = su.ratio_and_cov(freq, rtype="R102")
+            rat, cov102 = su.ratio_and_cov(freq, rtype="R102", threepoint=threepoint)
             datos102 = np.zeros((3, len(rat[:, 0])))
             datos102[0, :] = rat[:, 1]
             datos102[1, :] = rat[:, 3]

--- a/basta/freq_fit.py
+++ b/basta/freq_fit.py
@@ -9,7 +9,7 @@ from scipy.optimize import minimize
 from basta import utils_seismic as su
 
 
-def ratios(freq):
+def ratios(freq, threepoint=False):
     """
     Routine to compute the ratios (r02, r01 and r10) from oscillation
     frequencies
@@ -18,6 +18,9 @@ def ratios(freq):
     ----------
     freq : array
         Harmonic degrees, radial orders, frequencies
+    threepoint : bool
+        If True, use three point definition of r01 and r10 ratios
+        instead of default five point definition.
 
     Returns
     -------
@@ -89,63 +92,118 @@ def ratios(freq):
         r02[i, 1] = f0[i00 + i]["freq"] - f2[i02 + i]["freq"]
         r02[i, 1] /= f1[i01 + i + 1]["freq"] - f1[i01 + i]["freq"]
 
-    # Five-point frequency ratio (R01)
-    # ---------------------------------
-    # Find lowest indices for l = 0, 1, and 2
-    if f0[0]["n"] >= f1[0]["n"]:
-        i00 = 0
-        i01 = f0[0]["n"] - f1[0]["n"]
-    else:
-        i00 = f1[0]["n"] - f0[0]["n"]
-        i01 = 0
+    if not threepoint:
+        # Five-point frequency ratio R01
+        # ---------------------------------
+        # Find lowest indices for l = 0 and 1
+        if f0[0]["n"] >= f1[0]["n"]:
+            i00 = 0
+            i01 = f0[0]["n"] - f1[0]["n"]
+        else:
+            i00 = f1[0]["n"] - f0[0]["n"]
+            i01 = 0
 
-    # Number of r01s
-    if f0[-1]["n"] - 1 >= f1[-1]["n"]:
-        nr01 = f1[-1]["n"] - f1[i01]["n"]
-    else:
-        nr01 = f0[-1]["n"] - f0[i00]["n"] - 1
+        # Number of r01s
+        if f0[-1]["n"] - 1 >= f1[-1]["n"]:
+            nr01 = f1[-1]["n"] - f1[i01]["n"]
+        else:
+            nr01 = f0[-1]["n"] - f0[i00]["n"] - 1
 
-    # R01
-    r01 = np.zeros((nr01, 4))
-    for i in range(nr01):
-        r01[i, 0] = f0[i00 + i + 1]["n"]
-        r01[i, 3] = f0[i00 + i + 1]["freq"]
-        r01[i, 1] = (
-            f0[i00 + i]["freq"]
-            + 6.0 * f0[i00 + i + 1]["freq"]
-            + f0[i00 + i + 2]["freq"]
-        )
-        r01[i, 1] -= 4.0 * (f1[i01 + i + 1]["freq"] + f1[i01 + i]["freq"])
-        r01[i, 1] /= 8.0 * (f1[i01 + i + 1]["freq"] - f1[i01 + i]["freq"])
+        # R01
+        r01 = np.zeros((nr01, 4))
+        for i in range(nr01):
+            r01[i, 0] = f0[i00 + i + 1]["n"]
+            r01[i, 3] = f0[i00 + i + 1]["freq"]
+            r01[i, 1] = (
+                f0[i00 + i]["freq"]
+                + 6.0 * f0[i00 + i + 1]["freq"]
+                + f0[i00 + i + 2]["freq"]
+            )
+            r01[i, 1] -= 4.0 * (f1[i01 + i + 1]["freq"] + f1[i01 + i]["freq"])
+            r01[i, 1] /= 8.0 * (f1[i01 + i + 1]["freq"] - f1[i01 + i]["freq"])
 
-    # Five-point frequency ratio (R10)
-    # ---------------------------------
-    # Find lowest indices for l = 0, 1, and 2
-    if f0[0]["n"] - 1 >= f1[0]["n"]:
-        i00 = 0
-        i01 = f0[0]["n"] - f1[0]["n"] - 1
-    else:
-        i00 = f1[0]["n"] - f0[0]["n"] + 1
-        i01 = 0
+    elif threepoint:
+        # Five-point frequency ratio R01
+        # ---------------------------------
+        # Find lowest indices for l = 0 and 1
+        # i01 point to one n-value lower than i00
+        if f0[0]["n"] - 1 >= f1[0]["n"]:
+            i00 = 0
+            i01 = f0[0]["n"] - f1[0]["n"] - 1
+        else:
+            i00 = f1[0]["n"] - f0[0]["n"] + 1
+            i01 = 0
 
-    # Number of r10s
-    if f0[-1]["n"] >= f1[-1]["n"]:
-        nr10 = f1[-1]["n"] - f1[i01]["n"] - 1
-    else:
-        nr10 = f0[-1]["n"] - f0[i00]["n"]
+        # Number of r01s
+        if f0[-1]["n"] >= f1[-1]["n"]:
+            nr01 = f1[-1]["n"] - f1[i01]["n"]
+        else:
+            nr01 = f0[-1]["n"] - f0[i00]["n"] + 1
 
-    # R10
-    r10 = np.zeros((nr10, 4))
-    for i in range(nr10):
-        r10[i, 0] = f1[i01 + i + 1]["n"]
-        r10[i, 3] = f1[i01 + i + 1]["freq"]
-        r10[i, 1] = (
-            f1[i01 + i]["freq"]
-            + 6.0 * f1[i01 + i + 1]["freq"]
-            + f1[i01 + i + 2]["freq"]
-        )
-        r10[i, 1] -= 4.0 * (f0[i00 + i + 1]["freq"] + f0[i00 + i]["freq"])
-        r10[i, 1] /= -8.0 * (f0[i00 + i + 1]["freq"] - f0[i00 + i]["freq"])
+        # R01
+        r01 = np.zeros((nr01, 4))
+        for i in range(nr01):
+            r01[i, 0] = f0[i00 + i]["n"]
+            r01[i, 3] = f0[i00 + i]["freq"]
+            r01[i, 1] = f0[i00 + i]["freq"]
+            r01[i, 1] -= (f1[i01 + i + 1]["freq"] + f1[i01 + i]["freq"]) / 2.0
+            r01[i, 1] /= f1[i01 + i + 1]["freq"] - f1[i01 + i]["freq"]
+
+    if not threepoint:
+        # Five point frequency ratio R10
+        # ---------------------------------
+        # Find lowest indices for l = 0 and 1
+        if f0[0]["n"] - 1 >= f1[0]["n"]:
+            i00 = 0
+            i01 = f0[0]["n"] - f1[0]["n"] - 1
+        else:
+            i00 = f1[0]["n"] - f0[0]["n"] + 1
+            i01 = 0
+
+        # Number of r10s
+        if f0[-1]["n"] >= f1[-1]["n"]:
+            nr10 = f1[-1]["n"] - f1[i01]["n"] - 1
+        else:
+            nr10 = f0[-1]["n"] - f0[i00]["n"]
+
+        # R10
+        r10 = np.zeros((nr10, 4))
+        for i in range(nr10):
+            r10[i, 0] = f1[i01 + i + 1]["n"]
+            r10[i, 3] = f1[i01 + i + 1]["freq"]
+            r10[i, 1] = (
+                f1[i01 + i]["freq"]
+                + 6.0 * f1[i01 + i + 1]["freq"]
+                + f1[i01 + i + 2]["freq"]
+            )
+            r10[i, 1] -= 4.0 * (f0[i00 + i + 1]["freq"] + f0[i00 + i]["freq"])
+            r10[i, 1] /= -8.0 * (f0[i00 + i + 1]["freq"] - f0[i00 + i]["freq"])
+
+    elif threepoint:
+        # Three point frequency ratio R10
+        # ---------------------------------
+        # Find lowest indices for l = 0 and 1
+        if f0[0]["n"] >= f1[0]["n"]:
+            i00 = 0
+            i01 = f0[0]["n"] - f1[0]["n"]
+        else:
+            i00 = f1[0]["n"] - f0[0]["n"]
+            i01 = 0
+
+        # Number of r10s
+        if f0[-1]["n"] >= f1[-1]["n"]:
+            nr10 = f1[-1]["n"] - f1[i01]["n"]
+        else:
+            nr10 = f0[-1]["n"] - f0[i00]["n"]
+
+        # R10
+        r10 = np.zeros((nr10, 4))
+        for i in range(nr10):
+            r10[i, 0] = f1[i01 + i]["n"]
+            r10[i, 3] = f1[i01 + i]["freq"]
+            r10[i, 1] = f1[i01 + i]["freq"]
+            r10[i, 1] -= (f0[i00 + i]["freq"] + f0[i00 + i + 1]["freq"]) / 2.0
+            r10[i, 1] /= f0[i00 + i]["freq"] - f0[i00 + i + 1]["freq"]
 
     return r02, r01, r10
 
@@ -554,7 +612,7 @@ def cubicBG14(joinkeys, join, scalnu, method="l1", onlyl0=False):
     def l2(params, data, labels):
         prediction = np.dot(data, params.reshape(-1, 1))
         dist = prediction - labels
-        return (dist ** 2).sum()
+        return (dist**2).sum()
 
     if method == "ransac":
         np.random.seed(5)
@@ -694,7 +752,7 @@ def BG14(joinkeys, join, scalnu, method="l1", onlyl0=False):
     def l2(params, data, labels):
         prediction = np.dot(data, params.reshape(-1, 1))
         dist = prediction - labels
-        return (dist ** 2).sum()
+        return (dist**2).sum()
 
     if method == "ransac":
         np.random.seed(5)

--- a/basta/plot_seismic.py
+++ b/basta/plot_seismic.py
@@ -467,7 +467,9 @@ def duplicateechelle(
         print("Saved figure to " + output)
 
 
-def ratioplot(freqfile, datos, joinkeys, join, output=None, nonewfig=False):
+def ratioplot(
+    freqfile, datos, joinkeys, join, output=None, nonewfig=False, threepoint=False
+):
     """
     Plot frequency ratios.
 
@@ -488,6 +490,9 @@ def ratioplot(freqfile, datos, joinkeys, join, output=None, nonewfig=False):
     nonewfig : bool, optional
         If True, this creates a new canvas. Otherwise, the plot is added
         to the existing canvas.
+    threepoint : bool
+        If True, use three point definition of r01 and r10 ratios instead
+        of default five point definition.
     """
     # Load input ratios
     orders, ratio, ratio_types, errors, errors_m, errors_p = fio.read_ratios_xml(
@@ -540,7 +545,7 @@ def ratioplot(freqfile, datos, joinkeys, join, output=None, nonewfig=False):
     freq[:]["l"] = joinkeys[0, joinkeys[0, :] < 3]
     freq[:]["n"] = joinkeys[1, joinkeys[0, :] < 3]
     freq[:]["freq"] = join[0, joinkeys[0, :] < 3]
-    r02, r01, r10 = freq_fit.ratios(freq)
+    r02, r01, r10 = freq_fit.ratios(freq, threepoint=threepoint)
 
     if r02 is None:
         print("WARNING: missing radial orders! Skipping ratios plot.")

--- a/basta/stats.py
+++ b/basta/stats.py
@@ -73,6 +73,7 @@ def chi2_astero(
     fcor="BG14",
     seisw={},
     dnufit_in_ratios=True,
+    threepoint=False,
     warnings=True,
     shapewarn=False,
     debug=False,
@@ -137,6 +138,9 @@ def chi2_astero(
         Flag determining whether to add a large frequency separation term
         using corrected frequencies after surface correction in the ratios
         computation.
+    threepoint : bool
+        If True, use three point definition of r01 and r10 ratios, instead
+        of default five point definition.
     warnings : bool
         If True, print something when it fails.
     debug : str
@@ -210,7 +214,7 @@ def chi2_astero(
         freq[:]["l"] = joinkeys[0, joinkeys[0, :] < 3]
         freq[:]["n"] = joinkeys[1, joinkeys[0, :] < 3]
         freq[:]["freq"] = join[0, joinkeys[0, :] < 3]
-        r02, r01, r10 = freq_fit.ratios(freq)
+        r02, r01, r10 = freq_fit.ratios(freq, threepoint=threepoint)
         if r02 is not None:
             if any([x in tipo for x in ["r010", "r012", "r102"]]):
                 r010, r012, r102 = su.combined_ratios(r02, r01, r10)

--- a/basta/stats.py
+++ b/basta/stats.py
@@ -72,7 +72,7 @@ def chi2_astero(
     bfit=None,
     fcor="BG14",
     seisw={},
-    dnufit_in_ratios=True,
+    dnufit_in_ratios=False,
     threepoint=False,
     warnings=True,
     shapewarn=False,

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -485,6 +485,9 @@ def run_xml(
         correlations = strtobool(
             _find_get(root, "default/freqparams/correlations", "value")
         )
+        threepoint = strtobool(
+            _find_get(root, "default/freqparams/threepoint", "value", defa=False)
+        )
         dnufrac = float(_find_get(root, "default/freqparams/dnufrac", "value"))
         inputparams["fcor"] = fcor
         inputparams["dnufrac"] = dnufrac
@@ -687,6 +690,7 @@ def run_xml(
                     bexp,
                     freqfittypes,
                     seismicweights,
+                    threepoint,
                 )
 
                 inputparams["fitfreqs"] = freqinput

--- a/docs/examples_freqs.rst
+++ b/docs/examples_freqs.rst
@@ -130,6 +130,10 @@ as follows:
 
    Frequency ratios of the best fit model to 16 Cyg A in the grid.
 
+BASTA uses by default the five-point small frequency separation formulation for computing the ratios, which is the
+recommended option. If the user should want to use the three-point formulation instead, this can be done by adding
+``"threepoint": True`` in the ``define_fit["freqparams"]`` dictionary.
+
 Frequency glitches
 ------------------
 

--- a/examples/xmlinput/create_inputfile_distance.py
+++ b/examples/xmlinput/create_inputfile_distance.py
@@ -229,6 +229,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_freqs.py
+++ b/examples/xmlinput/create_inputfile_freqs.py
@@ -221,6 +221,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_glitches.py
+++ b/examples/xmlinput/create_inputfile_glitches.py
@@ -221,6 +221,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_global.py
+++ b/examples/xmlinput/create_inputfile_global.py
@@ -222,6 +222,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_interp_MS.py
+++ b/examples/xmlinput/create_inputfile_interp_MS.py
@@ -222,6 +222,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_json.py
+++ b/examples/xmlinput/create_inputfile_json.py
@@ -222,6 +222,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_parallax.py
+++ b/examples/xmlinput/create_inputfile_parallax.py
@@ -229,6 +229,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_phase.py
+++ b/examples/xmlinput/create_inputfile_phase.py
@@ -231,6 +231,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_ratios.py
+++ b/examples/xmlinput/create_inputfile_ratios.py
@@ -222,6 +222,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {

--- a/examples/xmlinput/create_inputfile_subgiant.py
+++ b/examples/xmlinput/create_inputfile_subgiant.py
@@ -218,6 +218,10 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     #                    * "1/N-dof": Normalisation by number of frequencies minus the
     #                                 (user-specified) degrees of freedom. This option
     #                                 must be supplemented by a specification of "dof".
+    # - "threepoint": Set 'True' to change to the three-point small frequency separation
+    #                 formulation for the frequency ratios, instead of the five-point
+    #                 small frequency separation. The default, if not set or set as
+    #                 'False', is to use the five-point formulation.
 
     # Example of typical settings for a frequency fit (with default seismic weights):
     # define_fit["freqparams"] = {


### PR DESCRIPTION
Add the option to use 3-point seperation ratios instead of the default 5-point. This is useful for reproducing older results or results from other groups.

Additionally, the default of `dnufit_in_ratios` is changed to `False` (as it ought to have been always).