### PR TITLE
Rewrite _find_get to handle bools and added defaults for freqfit

### DIFF
--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -28,7 +28,7 @@ else:
     INTPOL_AVAIL = True
 
 
-def _find_get(root, path, value, defa=False):
+def _find_get(root, path, value, *default):
     """
     Error catching of things required to be set in xml. Gives useful
     errormessage instead of stuff like "AttributeError: 'NoneType' object
@@ -42,7 +42,7 @@ def _find_get(root, path, value, defa=False):
         What path in the xml-tree the wanted value should be at
     value : str
         Name of the value to be extracted, e.g. "value", "path", "error"
-    defa : str, int, None
+    default : str, int, None, bool
         Default to return if not set
 
     Returns
@@ -50,16 +50,19 @@ def _find_get(root, path, value, defa=False):
     val : str
         Extracted value upon location in xml
     """
+    # Protect against calls like
+    # _find_get(root, path, value, 0, "foo", 42, None, True, [1, 2])
+    assert len(default) <= 1
     tag = path.split("/")[-1]
     place = root.find(path)
     if place == None:
-        if defa != False:
-            return defa
+        if default:
+            return default[0]
         raise KeyError("Missing tag '{0}' in input!".format(tag))
     val = place.get(value)
     if val == None:
-        if defa != False:
-            return defa
+        if default:
+            return default[0]
         raise ValueError("Missing '{0}' in tag '{1}'!".format(value, tag))
     return val
 
@@ -477,18 +480,18 @@ def run_xml(
     # Extract parameters for frequency fitting
     if fitfreqs:
         freqpath = _find_get(root, "default/freqparams/freqpath", "value")
-        fcor = _find_get(root, "default/freqparams/fcor", "value")
+        fcor = _find_get(root, "default/freqparams/fcor", "value", "cubicBG14")
         if fcor == "HK08":
             bexp = float(_find_get(root, "default/freqparams/bexp", "value"))
         else:
             bexp = None
         correlations = strtobool(
-            _find_get(root, "default/freqparams/correlations", "value")
+            _find_get(root, "default/freqparams/correlations", "value", "False")
         )
         threepoint = strtobool(
-            _find_get(root, "default/freqparams/threepoint", "value", defa=False)
+            _find_get(root, "default/freqparams/threepoint", "value", "False")
         )
-        dnufrac = float(_find_get(root, "default/freqparams/dnufrac", "value"))
+        dnufrac = float(_find_get(root, "default/freqparams/dnufrac", "value", 0.15))
         inputparams["fcor"] = fcor
         inputparams["dnufrac"] = dnufrac
 


### PR DESCRIPTION
When during frequency fitting I discovered that it was required of me to specify `threepoint=False` in the freqparams xml tag.
That makes no sense as (i) that is for ratio fitting and (ii) it should be False by default.

I then discovered that `_find_get` could not handle the default value of `threeport=False`. This is a rewrite of that function.

While I was at it, I added defaults for fcor (cubicBG14), correlations (False), and dnufrac (0.15).