### PR TITLE
Fix a crash when BayestarQuery is down

### DIFF
--- a/basta/distances.py
+++ b/basta/distances.py
@@ -111,13 +111,16 @@ def LOS_reddening(distanceparams):
         Egr_samples = np.array([np.nan])
 
         # Run through nsides
-        for ncont in reversed(nsides):
-            healpixNside = ang2pix(ncont, theta, phi, nest=True)
-            indNside = np.where(np.asarray([x[0] for x in pinfo]) == ncont)[0]
-            dcubepixNside = [x[1] for x in pinfo[indNside]]
-            kNside = int(bisect_left(dcubepixNside, healpixNside)) + indNside[0]
-            if healpixNside == dcubepixNside[kNside - indNside[0]]:
-                index = kNside
+        for nside in reversed(nsides):
+            healpixNside = ang2pix(nside, theta, phi, nest=True)
+            # Find the one with the correct nside and the correct healpix
+            indNside = [
+                i
+                for i, x in enumerate(pinfo)
+                if x[0] == nside and x[1] == healpixNside
+            ]
+            if indNside:
+                index = indNside[0]
                 Egr_samples = dcube["/samples"][index]
                 break
 


### PR DESCRIPTION
Due to a fencepost error, the code raises IndexError. Reimplement using a simpler approach.
The old approach used a binary search, which is efficient, but it also did a linear search, which is slow. Replace with a single linear search.

See also: https://github.com/gregreen/dustmaps/issues/42