### PR TITLE
Intpol optimise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ examples/grids/
 
 # Editor
 *.swp
+.vscode/
 
 # Folder for downloading/storing the dustmaps
 dustmaps/

--- a/basta/bastamain.py
+++ b/basta/bastamain.py
@@ -785,6 +785,11 @@ def BASTA(
             "Warning: Models without frequencies overlapping with observed",
             "ignored due to interpolation of ratios being impossible.",
         )
+    if shapewarn == 3:
+        print(
+            "Warning: Models ignored due to phase shift differences being",
+            "unapplicable to models with mixed modes.",
+        )
     if noofposind == 0:
         fio.no_models(starid, inputparams, "No models found")
         return

--- a/basta/freq_fit.py
+++ b/basta/freq_fit.py
@@ -1105,6 +1105,10 @@ def compute_epsilondiffseqs(
 
         Niter += len(diff_eps0l)
 
+    # Mixed modes results in negative differences. Flag using nans
+    mask = np.where(deps[0, :] < 0)[0]
+    deps[0, mask] = np.nan
+
     # Sort according to n if flagged (ensure l=1 before l=2 with 0.1)
     if nsorting:
         mask = np.argsort(deps[3, :] + deps[2, :] * 0.1)

--- a/basta/freq_fit.py
+++ b/basta/freq_fit.py
@@ -1105,10 +1105,6 @@ def compute_epsilondiffseqs(
 
         Niter += len(diff_eps0l)
 
-    # Mixed modes results in negative differences. Flag using nans
-    mask = np.where(deps[0, :] < 0)[0]
-    deps[0, mask] = np.nan
-
     # Sort according to n if flagged (ensure l=1 before l=2 with 0.1)
     if nsorting:
         mask = np.argsort(deps[3, :] + deps[2, :] * 0.1)

--- a/basta/interpolation_combined.py
+++ b/basta/interpolation_combined.py
@@ -182,6 +182,17 @@ def interpolate_combined(
     print("Locating limits and restricting sub-grid ... ", flush=True)
     selectedmodels = ih.get_selectedmodels(grid, basepath, limits, cut=False)
 
+    # Check we have enough source tracks in the sub-box to form a simplex
+    if len(selectedmodels) < len(pars_sampled) + 1:
+        warstr = "Sub-box contains only {:d} tracks, while ".format(len(selectedmodels))
+        warstr += "{:d} is needed for interpolation in the ".format(
+            len(pars_sampled) + 1
+        )
+        warstr += (
+            "parameter space of the input grid. Consider expanding sub-box (limits)."
+        )
+        raise ValueError(warstr)
+
     if extend:
         for name, index in selectedmodels.items():
             # If below 3 models in subbox, skip the track
@@ -195,6 +206,11 @@ def interpolate_combined(
                     outfile[keypath] = grid[keypath][()]
                 else:
                     outfile[keypath] = grid[keypath][index]
+            if intpol_freqs:
+                index2d = np.array(np.transpose([index, index]))
+                for key in ["osc", "osckey"]:
+                    keypath = os.path.join(basepath, name, key)
+                    outfile[keypath] = grid[keypath][index2d].reshape(-1, 2)
 
     # Form the base array for interpolation
     base = np.zeros((len(selectedmodels), len(pars_sampled)))

--- a/basta/interpolation_combined.py
+++ b/basta/interpolation_combined.py
@@ -338,8 +338,7 @@ def interpolate_combined(
         # Create triangulation of tinerpolation base once only
         sub_triangle = spatial.Delaunay(intbase)
 
-        if True:
-            # try:
+        try:
             ################################
             # BLOCK 2a: Classic parameters #
             ################################
@@ -451,19 +450,19 @@ def interpolate_combined(
             # Success! Set status as completed
             outfile[os.path.join(libname, "IntStatus")] = 0
 
-        # except KeyboardInterrupt:
-        #     print("Interpolation stopped manually. Goodbye!")
-        #     sys.exit()
-        # except:
-        #     # If it fails, delete progress for the track, and just mark it as failed
-        #     try:
-        #         del outfile[libname]
-        #     except:
-        #         pass
-        #     success[tracknum] = False
-        #     print("Error:", sys.exc_info()[1])
-        #     outfile[os.path.join(libname, "IntStatus")] = -1
-        #     print("Interpolation failed for track {0}".format(newnum + tracknum))
+        except KeyboardInterrupt:
+            print("Interpolation stopped manually. Goodbye!")
+            sys.exit()
+        except:
+            # If it fails, delete progress for the track, and just mark it as failed
+            try:
+                del outfile[libname]
+            except:
+                pass
+            success[tracknum] = False
+            print("Error:", sys.exc_info()[1])
+            outfile[os.path.join(libname, "IntStatus")] = -1
+            print("Interpolation failed for track {0}".format(newnum + tracknum))
 
     ####################
     # End of main loop #

--- a/basta/interpolation_combined.py
+++ b/basta/interpolation_combined.py
@@ -385,7 +385,7 @@ def interpolate_combined(
                         yind = selectedmodels[tracknames[i]]
                         y[sections[j] : sections[j + 1]] = grid[track][key][yind]
 
-                    # Interpolate, chec for NaNs
+                    # Interpolate, check for NaNs
                     newparam = ih.interpolation_wrapper(
                         sub_triangle, y, newbase, along=False
                     )

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -394,12 +394,12 @@ def _interpolate_grid(
                 if type(vec) != np.ndarray:
                     continue
                 # If osc or osckey, transform to 2D index array
-                elif len(vec.shape) > 1:  # key in ["osc", "osckey"]:
+                elif len(vec.shape) > 1:
                     nv = vec.shape[1]
                     indexNd = np.array(np.transpose([index for _ in range(nv)]))
                     vec = vec[indexNd].reshape((-1, nv))
                 else:
-                    vec = outfile[keypath][index]
+                    vec = vec[index]
                 del outfile[keypath]
                 outfile[keypath] = vec
 

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -97,7 +97,7 @@ def _unpack_intpol(intpol, dnusun, basepath):
         The parameters(s) set for limiting the models considered in the input grid.
     """
     # Possible cases
-    cases = ["along", "across", "combined", "alongacross", "acrossalong"]
+    cases = ["along", "across", "combined"]
 
     # Initialise what to unpack
     trackres, gridres, limits, alongvar = None, None, {}, None
@@ -174,10 +174,46 @@ def _unpack_intpol(intpol, dnusun, basepath):
     return case, trackres, gridres, limits, alongvar
 
 
+def _copy_tracks(grid, outfile, basepath, intpolparams, selectedmodels, intpol_freqs):
+    """
+    If the extend option has been enabled, copy the sub-box of old models
+    to the new gridfile.
+
+    """
+
+    if "grid" in basepath:
+        intpolparams = np.unique(np.append(intpolparams, "dage"))
+    else:
+        intpolparams = np.unique(np.append(intpolparams, "dmass"))
+
+    headvars = [
+        p.decode("UTF-8")
+        for x in ["pars_sampled", "pars_variable", "pars_constant"]
+        for p in grid["header"][x]
+    ]
+    for name, index in selectedmodels.items():
+        # If below 3 models in subbox, skip the track
+        if sum(index) < 3:
+            continue
+        # Add IntStatus as copied original track
+        outfile[os.path.join(basepath, name, "IntStatus")] = 1
+        for key in np.unique([*intpolparams, *headvars]):
+            keypath = os.path.join(basepath, name, key)
+            if "_weight" in key:
+                outfile[keypath] = grid[keypath][()]
+            else:
+                outfile[keypath] = grid[keypath][index]
+        if intpol_freqs:
+            index2d = np.array(np.transpose([index, index]))
+            for key in ["osc", "osckey"]:
+                keypath = os.path.join(basepath, name, key)
+                outfile[keypath] = grid[keypath][index2d].reshape(-1, 2)
+
+
 # ======================================================================================
 # Main processing routine
 # ======================================================================================
-def interpolate_grid(
+def _interpolate_grid(
     gridname,
     outname,
     inputdict,
@@ -186,7 +222,6 @@ def interpolate_grid(
     basepath="grid/",
     outbasename="",
     debug=False,
-    verbose=False,
 ):
     """
     Select a part of a BASTA grid based on observational limits. Interpolate all
@@ -277,52 +312,62 @@ def interpolate_grid(
     if "freqs" in intpolparams:
         intpolparams.remove("freqs")
         intpolparams += ["tau0", "tauhe", "taubcz", "dnufit"]
-        intpol_freqs = True
-    # Determine if individual frequencies should be interpolated
-    if case in ["along", "combined", "alongacross"]:
+        intpol_freqs = limits["freqs"]
+    # Determine if individual frequencies should be used for interpolation along
+    if case in ["along", "combined"]:
         if trackresolution["param"] in freqres:
-            intpol_freqs = True
+            intpol_freqs = limits["freqs"]
     if intpol_freqs:
         print("Warning: Interpolation of individual oscillation frequencies requested!")
     intpolparams = list(np.unique(intpolparams))
 
+    # Extract models within user-specified limits
+    print("Locating limits and restricting sub-grid ... ", flush=True)
+    selectedmodels = ih.get_selectedmodels(grid, basepath, limits, cut=False)
+
+    # If extend option is chosen (keep old sub-box of models)
+    if case in ["combined", "across"] and (
+        gridresolution["extend"] or not gridresolution["sobol"]
+    ):
+        _copy_tracks(
+            grid, outfile, basepath, intpolparams, selectedmodels, intpol_freqs
+        )
+
     # Interpolate according to each of the possible cases
     if case == "along":
-        grid, outfile, fail = ial.interpolate_along(
+        ial.interpolate_along(
             grid,
             outfile,
-            limits,
+            selectedmodels,
             trackresolution,
             intpolparams,
             basepath,
             intpol_freqs,
             debug,
-            verbose,
         )
-        grid, outfile = ih.write_header(grid, outfile, basepath)
+        ih.write_header(grid, outfile, basepath)
         grid.close()
     elif case == "across":
-        grid, outfile = ih.write_header(grid, outfile, basepath)
-        grid, outfile, fail = iac.interpolate_across(
+        ih.write_header(grid, outfile, basepath)
+        iac.interpolate_across(
             grid,
             outfile,
             gridresolution,
-            limits,
+            selectedmodels,
             intpolparams,
             basepath,
             intpol_freqs,
             alongvar,
             outbasename,
             debug,
-            verbose,
         )
         grid.close()
     elif case == "combined":
-        grid, outfile = ih.write_header(grid, outfile, basepath)
+        ih.write_header(grid, outfile, basepath)
         ico.interpolate_combined(
             grid,
             outfile,
-            limits,
+            selectedmodels,
             trackresolution,
             gridresolution,
             intpolparams,
@@ -331,62 +376,7 @@ def interpolate_grid(
             outbasename,
             debug,
         )
-    elif case == "acrossalong":
-        grid, outfile = ih.write_header(grid, outfile, basepath)
-        grid, outfile, fail = iac.interpolate_across(
-            grid,
-            outfile,
-            gridresolution,
-            limits,
-            intpolparams,
-            basepath,
-            intpol_freqs,
-            alongvar,
-            outbasename,
-            debug,
-            verbose,
-        )
         grid.close()
-        outfile, outfile, fail = ial.interpolate_along(
-            outfile,
-            outfile,
-            limits,
-            trackresolution,
-            intpolparams,
-            basepath,
-            intpol_freqs,
-            debug,
-            verbose,
-        )
-    elif case == "alongacross":
-        grid, outfile, fail = ial.interpolate_along(
-            grid,
-            outfile,
-            limits,
-            trackresolution,
-            intpolparams,
-            basepath,
-            intpol_freqs,
-            debug,
-            verbose,
-        )
-        grid, outfile = ih.write_header(grid, outfile, basepath)
-        # Grid can be closed now, across will use the along interpolated grid as input
-        grid.close()
-        if not fail:
-            outfile, outfile, fail = iac.interpolate_across(
-                outfile,
-                outfile,
-                gridresolution,
-                limits,
-                intpolparams,
-                basepath,
-                intpol_freqs,
-                alongvar,
-                outbasename,
-                debug,
-                verbose,
-            )
 
     print("\n*********************\nInterpolation wrap-up\n*********************")
 
@@ -421,7 +411,11 @@ def interpolate_grid(
 
 
 def perform_interpolation(
-    grid, idgrid, intpol, inputparams, debug=False, verbose=False
+    grid,
+    idgrid,
+    intpol,
+    inputparams,
+    debug=False,
 ):
     """
     Setup and call of main interpolation driver.
@@ -538,7 +532,7 @@ def perform_interpolation(
 
     # Run the external routine
     it0 = time.localtime()
-    interpolate_grid(
+    _interpolate_grid(
         gridname=grid,
         outname=intpolgrid,
         inputdict=intpol,
@@ -547,7 +541,6 @@ def perform_interpolation(
         basepath=basepath,
         outbasename=outbasename,
         debug=debug,
-        verbose=verbose,
     )
     it1 = time.localtime()
     dt = time.mktime(it1) - time.mktime(it0)

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -319,6 +319,21 @@ def interpolate_grid(
         grid.close()
     elif case == "combined":
         grid, outfile = ih._write_header(grid, outfile, basepath)
+        ico.interpolate_combined(
+            grid,
+            outfile,
+            limits,
+            trackresolution,
+            gridresolution,
+            intpolparams,
+            basepath,
+            intpol_freqs,
+            False,
+            outbasename,
+            debug,
+        )
+    elif case == "acrossalong":
+        grid, outfile = ih._write_header(grid, outfile, basepath)
         grid, outfile, fail = iac._interpolate_across(
             grid,
             outfile,
@@ -401,9 +416,9 @@ def interpolate_grid(
     outfile[os.path.join("header", "interpolation_time")] = time.strftime(
         "%Y-%m-%d at %H:%M:%S"
     )
+    print(intpolparams)
+    print(list(outfile["grid/tracks/track270"]))
     outfile.close()
-    if fail:
-        raise RuntimeError("Interpolation failed!")
 
 
 def perform_interpolation(

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -14,6 +14,7 @@ from basta.utils_general import Logger
 from basta import interpolation_helpers as ih
 from basta import interpolation_across as iac
 from basta import interpolation_along as ial
+from basta import interpolation_combined as ico
 
 
 # ======================================================================================

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -97,7 +97,7 @@ def _unpack_intpol(intpol, dnusun, basepath):
         The parameters(s) set for limiting the models considered in the input grid.
     """
     # Possible cases
-    cases = ["along", "across", "combined", "alongacross"]
+    cases = ["along", "across", "combined", "alongacross", "acrossalong"]
 
     # Initialise what to unpack
     trackres, gridres, limits, alongvar = None, None, {}, None
@@ -288,7 +288,7 @@ def interpolate_grid(
 
     # Interpolate according to each of the possible cases
     if case == "along":
-        grid, outfile, fail = ial._interpolate_along(
+        grid, outfile, fail = ial.interpolate_along(
             grid,
             outfile,
             limits,
@@ -299,11 +299,11 @@ def interpolate_grid(
             debug,
             verbose,
         )
-        grid, outfile = ih._write_header(grid, outfile, basepath)
+        grid, outfile = ih.write_header(grid, outfile, basepath)
         grid.close()
     elif case == "across":
-        grid, outfile = ih._write_header(grid, outfile, basepath)
-        grid, outfile, fail = iac._interpolate_across(
+        grid, outfile = ih.write_header(grid, outfile, basepath)
+        grid, outfile, fail = iac.interpolate_across(
             grid,
             outfile,
             gridresolution,
@@ -318,7 +318,7 @@ def interpolate_grid(
         )
         grid.close()
     elif case == "combined":
-        grid, outfile = ih._write_header(grid, outfile, basepath)
+        grid, outfile = ih.write_header(grid, outfile, basepath)
         ico.interpolate_combined(
             grid,
             outfile,
@@ -333,8 +333,8 @@ def interpolate_grid(
             debug,
         )
     elif case == "acrossalong":
-        grid, outfile = ih._write_header(grid, outfile, basepath)
-        grid, outfile, fail = iac._interpolate_across(
+        grid, outfile = ih.write_header(grid, outfile, basepath)
+        grid, outfile, fail = iac.interpolate_across(
             grid,
             outfile,
             gridresolution,
@@ -348,7 +348,7 @@ def interpolate_grid(
             verbose,
         )
         grid.close()
-        outfile, outfile, fail = ial._interpolate_along(
+        outfile, outfile, fail = ial.interpolate_along(
             outfile,
             outfile,
             limits,
@@ -360,7 +360,7 @@ def interpolate_grid(
             verbose,
         )
     elif case == "alongacross":
-        grid, outfile, fail = ial._interpolate_along(
+        grid, outfile, fail = ial.interpolate_along(
             grid,
             outfile,
             limits,
@@ -371,11 +371,11 @@ def interpolate_grid(
             debug,
             verbose,
         )
-        grid, outfile = ih._write_header(grid, outfile, basepath)
+        grid, outfile = ih.write_header(grid, outfile, basepath)
         # Grid can be closed now, across will use the along interpolated grid as input
         grid.close()
         if not fail:
-            outfile, outfile, fail = iac._interpolate_across(
+            outfile, outfile, fail = iac.interpolate_across(
                 outfile,
                 outfile,
                 gridresolution,
@@ -416,8 +416,6 @@ def interpolate_grid(
     outfile[os.path.join("header", "interpolation_time")] = time.strftime(
         "%Y-%m-%d at %H:%M:%S"
     )
-    print(intpolparams)
-    print(list(outfile["grid/tracks/track270"]))
     outfile.close()
 
 

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -327,7 +327,7 @@ def _interpolate_grid(
 
     # If extend option is chosen (keep old sub-box of models)
     if case in ["combined", "across"] and (
-        gridresolution["extend"] or not gridresolution["sobol"]
+        gridresolution["extend"] or not gridresolution["scale"]
     ):
         _copy_tracks(
             grid, outfile, basepath, intpolparams, selectedmodels, intpol_freqs

--- a/basta/interpolation_driver.py
+++ b/basta/interpolation_driver.py
@@ -328,7 +328,6 @@ def interpolate_grid(
             intpolparams,
             basepath,
             intpol_freqs,
-            False,
             outbasename,
             debug,
         )
@@ -401,12 +400,14 @@ def interpolate_grid(
             libname = os.path.join(basepath, name)
             for key in outfile[libname].keys():
                 keypath = os.path.join(libname, key)
-                if type(outfile[keypath][()]) != np.ndarray:
+                vec = outfile[keypath][()]
+                if type(vec) != np.ndarray:
                     continue
                 # If osc or osckey, transform to 2D index array
-                elif key in ["osc", "osckey"]:
-                    index2d = np.array(np.transpose([index, index]))
-                    vec = outfile[keypath][index2d].reshape((-1, 2))
+                elif len(vec.shape) > 1:  # key in ["osc", "osckey"]:
+                    nv = vec.shape[1]
+                    indexNd = np.array(np.transpose([index for _ in range(nv)]))
+                    vec = vec[indexNd].reshape((-1, nv))
                 else:
                     vec = outfile[keypath][index]
                 del outfile[keypath]

--- a/basta/interpolation_helpers.py
+++ b/basta/interpolation_helpers.py
@@ -224,7 +224,7 @@ def calc_along_points(intbase, lens, minmax, point, envres=None, resvalue=None):
             yind += l
         envminmax[0] = max(envminmax[0])
         envminmax[1] = min(envminmax[1])
-        Nres = int(np.ceil((envminmax[1] - envminmax[0]) / resvalue))
+        Nres = int(abs(np.ceil((envminmax[1] - envminmax[0]) / resvalue)))
         yind = 0
 
     if not resvalue:
@@ -769,19 +769,24 @@ def recalculate_weights(outfile, basepath, sobnums, extend=False):
         bpars = outfile["header/pars_sampled"]
         # Collect basis parameters
         base = np.zeros((len(index), len(bpars)))
-        iter = zip(IntStatus, outfile[basepath].items())
-        for i, (ist, (_, libitem)) in enumerate(iter):
-            if ist != 1:
-                continue
-            for j, par in enumerate(bpars):
-                base[i, j] = libitem[par][0]
+        gid = 0
+        lid = 0
+        for gname, group in outfile[basepath].items():
+            iter = zip(IntStatus[gid : gid + len(group)], group.items())
+            for i, (ist, (_, libitem)) in enumerate(iter):
+                if ist != 1:
+                    continue
+                for j, par in enumerate(bpars):
+                    base[lid, j] = libitem[par][0]
+                lid += 1
+            gid += len(group)
 
         for i, par in enumerate(bpars):
             mm = [min(base[:, i]), max(base[:, i])]
             base[:, i] -= mm[0]
             base[:, i] /= mm[1] - mm[0]
 
-        sobnum = np.vstack((base, sobnum))
+        sobnums = np.vstack((base, sobnums))
 
     mask = np.where(np.array(IntStatus) >= 0)[0]
     active = np.asarray(names)[mask]

--- a/basta/interpolation_helpers.py
+++ b/basta/interpolation_helpers.py
@@ -66,7 +66,7 @@ def bay_weights(inputvar):
 # ======================================================================================
 # Common interpolation functions
 # ======================================================================================
-def _interpolation_wrapper(x, y, xnew, method="linear", along=True):
+def interpolation_wrapper(x, y, xnew, method="linear", along=True):
     """
     Interpolate a 1-D function using the specified method.
 

--- a/basta/interpolation_helpers.py
+++ b/basta/interpolation_helpers.py
@@ -379,7 +379,7 @@ def interpolate_frequencies(
     """
 
     available_lvalues = [0, 1, 2]
-
+    along = type(triangulation) == np.ndarray
     #
     # *** BLOCK 1: Determine and allocate matrix sizes ***
     #
@@ -511,6 +511,7 @@ def interpolate_frequencies(
                     triangulation,
                     matrix[fi][nn][:],
                     newvec,
+                    along=along,
                 )
 
         # Store new frequencies
@@ -612,7 +613,7 @@ def update_header(outfile, basepath, headvars):
     return outfile
 
 
-def _write_header(grid, outfile, basepath):
+def write_header(grid, outfile, basepath):
     """
     Write the header of the new grid. Basically copies the old header.
 
@@ -667,7 +668,7 @@ def _write_header(grid, outfile, basepath):
     return grid, outfile
 
 
-def _recalculate_param_weights(outfile, basepath):
+def recalculate_param_weights(outfile, basepath):
     """
     Recalculates the weights of the tracks/isochrones, for the new grid.
     Tracks not transferred from old grid has IntStatus = -1.

--- a/basta/interpolation_helpers.py
+++ b/basta/interpolation_helpers.py
@@ -585,9 +585,7 @@ def update_header(outfile, basepath, headvars):
 
     Returns
     -------
-    outfile : hdf5 file
-        New grid file to write to.
-
+    None
     """
 
     # Number of tracks in grid
@@ -610,7 +608,6 @@ def update_header(outfile, basepath, headvars):
         else:
             del outfile[headpath]
             outfile[headpath] = [b"Interpolated"] * ltracks
-    return outfile
 
 
 def write_header(grid, outfile, basepath):
@@ -631,12 +628,7 @@ def write_header(grid, outfile, basepath):
 
     Returns
     -------
-    grid : h5py file
-        Handle of grid to process
-
-    outfile : h5py file
-        Handle of output grid to write to
-
+    None
     """
     # Needs to run before across interpolation for access to header lists during.
     # Duplicate the header to the new grid file.
@@ -665,8 +657,6 @@ def write_header(grid, outfile, basepath):
                 keystr = os.path.join("solar_models", topkey, key)
                 outfile[keystr] = grid[keystr][()]
 
-    return grid, outfile
-
 
 def recalculate_param_weights(outfile, basepath):
     """
@@ -687,9 +677,7 @@ def recalculate_param_weights(outfile, basepath):
 
     Returns
     -------
-    outfile : hdf5 file
-        New grid file to write to.
-
+    None
     """
     isomode = False if "grid" in basepath else True
     headvars = outfile["header/active_weights"][()]
@@ -724,7 +712,6 @@ def recalculate_param_weights(outfile, basepath):
             else:
                 del outfile[weight_path]
                 outfile[weight_path] = weights[i]
-    return outfile
 
 
 def recalculate_weights(outfile, basepath, sobnums, extend=False):
@@ -750,9 +737,7 @@ def recalculate_weights(outfile, basepath, sobnums, extend=False):
 
     Returns
     -------
-    outfile : hdf5 file
-        New grid file to write to.
-
+    None
     """
     # Collect the relevant tracks/isochrones
     IntStatus = []
@@ -832,8 +817,6 @@ def recalculate_weights(outfile, basepath, sobnums, extend=False):
     # Write the active weights as only volume
     del outfile["header/active_weights"]
     outfile["header/active_weights"] = ["volume"]
-
-    return outfile
 
 
 # ======================================================================================

--- a/basta/interpolation_helpers.py
+++ b/basta/interpolation_helpers.py
@@ -4,6 +4,7 @@ Interpolation for BASTA: Helper routines
 import os
 
 import numpy as np
+import bottleneck as bn
 from tqdm import tqdm
 from scipy import interpolate
 import matplotlib.pyplot as plt
@@ -66,7 +67,7 @@ def bay_weights(inputvar):
 # ======================================================================================
 # Common interpolation functions
 # ======================================================================================
-def interpolation_wrapper(x, y, xnew, method="linear", along=True):
+def interpolation_wrapper(x, y, xnew, method="linear", along=False):
     """
     Interpolate a 1-D function using the specified method.
 
@@ -158,6 +159,8 @@ def get_selectedmodels(grid, basepath, limits, cut=True, show_progress=True):
             # Full list of indexes, set False if model outside limits
             index = np.ones(len(libitem["age"][:]), dtype=bool)
             for param in limits:
+                if "freq" in param:
+                    continue
                 index &= libitem[param][:] >= limits[param][0]
                 index &= libitem[param][:] <= limits[param][1]
             # Patch index array if it should not be cut
@@ -174,16 +177,157 @@ def get_selectedmodels(grid, basepath, limits, cut=True, show_progress=True):
     return selectedmodels
 
 
+def calc_along_points(intbase, lens, minmax, point, envres=None, resvalue=None):
+    """
+    Creates new along vector by interpolating from along vectors of
+    enveloping tracks from model numbers to mimic spacing in parameter.
+    E.g. if the enveloping tracks have a high resolution at the start,
+    but low at the end, this function attempts to reproduce that for the
+    interpolated track. It does so by normalising the model numbers to
+    an interval between 0 and 1 for each track, and use that as the
+    interpolation base.
+
+    Parameters
+    ----------
+    intbase : numpy array
+        Interpolation base vector of the enveloping tracks
+    lens : list
+        Lengths of the enveloping tracks to sub-divide the single array
+    minmax : list
+        Minimum and maximum values of along variable in the enveloping
+        tracks
+    point : list
+        Base parameter values for the interpolated track
+    envres : numpy array
+        Copy of intbase, but with along resolution variable of enveloping
+        tracks
+    resvalue : float
+        Along resolution to achieve
+
+    Returns
+    -------
+    out : numpy array
+        New 1D along variable vector for the interpolated track
+    """
+
+    # For counting and collecting during loop over tracks
+    yind = 0
+    mods = []
+    yvec = []
+    newl = []
+
+    if resvalue:
+        envminmax = [[], []]
+        for l in lens:
+            envminmax[0].append(min(envres[yind : yind + l, -1]))
+            envminmax[1].append(max(envres[yind : yind + l, -1]))
+            yind += l
+        envminmax[0] = max(envminmax[0])
+        envminmax[1] = min(envminmax[1])
+        Nres = int(np.ceil((envminmax[1] - envminmax[0]) / resvalue))
+        yind = 0
+
+    if not resvalue:
+        for i, l in enumerate(lens):
+            # Construct individual track bases
+            base = intbase[yind : yind + l, -1]
+            # Determine the models within limits
+            mask = np.ones(len(base), dtype=bool)
+            mask &= np.array(base) >= minmax[0]
+            mask &= np.array(base) <= minmax[1]
+            lbase = sum(mask)
+            newl.append(lbase)
+
+            if lbase < 1:
+                raise ValueError
+
+            # Variables for normalisation and to keep edges
+            dists = [0, 0]
+            offset = 0
+
+            # If the base does not dictate the limits, make appropriate edges
+            # If the start is not the limit of the interval, the first model
+            # within the interval will not be 0, but a little over, and the
+            # previous model will be included as a negativily numbered model.
+            if np.sum(mask) != len(base):
+                if not mask[0]:
+                    ind = np.where(base == base[mask][0])[0][0]
+                    ref = minmax[0 if base[0] < base[1] else 1]
+                    dists[0] += (base[ind] - ref) / (base[ind] - base[ind - 1])
+                    mask[np.where(mask)[0][0] - 1] = True
+                    offset = -1
+                if not mask[-1]:
+                    ind = np.where(base == base[mask][-1])[0][0]
+                    ref = minmax[1 if base[0] < base[1] else 0]
+                    dists[1] += (ref - base[ind]) / (base[ind + 1] - base[ind])
+                    mask[np.where(mask)[0][-1] + 1] = True
+
+            # Reform base to be within interval
+            newbase = base[mask]
+
+            # Normalisation of model "numbers" from 0 to 1 in interval
+            # "Ghost" models outside interval are kept for interpolation
+            mod = (np.arange(sum(mask)) + offset + dists[0]) / (lbase - 1 + sum(dists))
+            # Construct new interpolation base
+            fmod = intbase[yind : yind + lens[i], :][mask]
+            fmod[:, -1] = mod
+            mods.append(fmod)
+
+            # Compile list of along variable values
+            yvec += list(newbase)
+            # Update loop variable
+            yind += l
+
+        # Reconstruct base
+        intbase = mods[0]
+        for m in mods[1:]:
+            intbase = np.vstack((intbase, m))
+    else:
+        for i, l in enumerate(lens):
+            base = intbase[yind : yind + l, -1]
+            mask = np.ones(len(base), dtype=bool)
+            mask &= np.array(base) >= minmax[0]
+            mask &= np.array(base) <= minmax[1]
+            newl.append(sum(mask))
+
+            yvec += list(base)
+            yind += l
+        intbase = envres
+
+    # Make interpolator
+    intpol = interpolate.LinearNDInterpolator(intbase, yvec)
+
+    # Determine/adjust number of points
+    N = int(np.mean(newl))
+    if resvalue and N < Nres:
+        N = Nres
+    elif resvalue:
+        print("Warning: Reduced resolution from {0} to {1}".format(N, Nres))
+        N = Nres
+
+    # Making new interpolation base
+    # Putting them exactly on top creates boundary issues
+    if resvalue:
+        lin = np.linspace(envminmax[0], envminmax[1], N + 2)[1:-1]
+    else:
+        lin = np.linspace(0, 1, N + 2)[1:-1]
+    inp = np.ones((len(lin), len(point) + 1))
+    for i, p in enumerate(point):
+        inp[:, i] *= p
+    inp[:, -1] = lin
+
+    out = intpol(inp)
+
+    return out
+
+
 def interpolate_frequencies(
     fullosc,
     fullosckey,
-    agevec,
-    newagevec,
-    sections=None,
+    sections,
+    triangulation,
+    newvec,
     freqlims=None,
-    verbose=False,
-    debug=False,
-    trackid=None,
 ):
     """
     Perform interpolation in individual oscillation frequencies in a reduced track.
@@ -209,24 +353,18 @@ def interpolate_frequencies(
         Full reshaped array of oscillation keys, in terms of radial order n, and
         degree l
 
-    agevec : array
-        Ages of original reduced track. Used to define the interpolation object.
+    sections : list
+        Indexes indicating where each track starts and begins within the full
+        frequency arrays. Needed to quality check for missing frequencies in tracks.
 
-    newagevec : array
-        Mesh of ages where to evaluate the interpolation. Coordinates of new track.
+    triangulation : object
+        Delaunay triangulation of the base
 
-    sections : array or None
-        Toggle for 1D or ND interpolation, None for 1D, for ND array with indices that
-        gives the individual tracks from the full arrays, for quality check.
+    newvec : array
+        Base vector of the new track.
 
-    verbose : bool, optional
-        Print info.
-
-    debug : bool, optional
-        Print extra information. Plot *all* interpolated frequencies. Warning: Slow!
-
-    trackid : int, optional
-        Must be given when using full debug mode. ID of current track. Used for plots.
+    freqlims : list
+        Minimum and maximum frequencies to interpolate
 
     Returns
     -------
@@ -238,266 +376,189 @@ def interpolate_frequencies(
         Nested list with an entry per point in the new, interpolated track. Each entry
         is an array with frequencies and intertias. Following same definitions as
         BASTA/make_tracks.
-
     """
-    along = True if sections == None else False
-    if debug and along:
-        print("--> Warning: Slow setting selected! Plotting *all* frequencies.")
-        skipplots = False
-    else:
-        skipplots = True
 
-    # Globally define values of l present in the grid
     available_lvalues = [0, 1, 2]
 
     #
-    # *** BLOCK 1: Extract oscillations from the library into more accesible arrays ***
+    # *** BLOCK 1: Determine and allocate matrix sizes ***
     #
-    # Normally we are only interested in quantities one model at a time. However, that
-    # it not sufficient for interpolation purposes. Thus, we need to "unpack" all
-    # information of all models to interpolate each individual frequency across models.
-    #
-    # The arrays are called 'xval', with x \in {l, n, f, i} and can be indexed as
-    # >   fvals["l=L"][MODELINDEX]
-    # to obtain all frequencies with l=L for entry MODELINDEX.
-    #
-    # As an example: fvals["l=0"][-1][2] will yield the third (2) radial mode (l=0) for
-    # the last point in the track (-1). The corresponding degree of that mode is found
-    # as nvals["l=0""][-1][2].
-    Ntrack = len(fullosc)
-    nvals = {"l=0": [], "l=1": [], "l=2": []}
-    fvals = {"l=0": [], "l=1": [], "l=2": []}
-    ivals = {"l=0": [], "l=1": [], "l=2": []}
-    for modid in range(Ntrack):
-        for ll in available_lvalues:
-            osckey, osc = su.get_givenl(
-                l=ll,
-                osc=su.transform_obj_array(fullosc[modid]),
-                osckey=su.transform_obj_array(fullosckey[modid]),
-            )
-            lkey = "l={0}".format(ll)
-            nvals[lkey].append(osckey[1])
-            fvals[lkey].append(osc[0])
-            ivals[lkey].append(osc[1])
-
-    # Check if any lvalues can be omitted
+    # For computation efficiency, a matrix is allocated for each l-value,
+    # with rows corresponding to each n-value, columns corresponding to
+    # to each model, and a layer each for frequency and inertia of the mode.
+    # With a filler value of nan's for non-existing modes, no resizing or
+    # continuous checking of the modes is needed, as all other functions
+    # neatly passes nan on.
     bad = []
+    freqs = {}
+    nranges = {}
+    Ntrack = len(fullosc)
     for ll in available_lvalues:
-        lkey = "l={0}".format(ll)
-        if not any([len(arr) for arr in nvals[lkey]]):
+        # Get n-value range
+        nmin = 999
+        nmax = -999
+        for modid in range(Ntrack):
+            mask = fullosckey[modid][0] == ll
+            if not len(mask):
+                continue
+            nmin = min(nmin, fullosckey[modid][1][mask][0])
+            nmax = max(nmax, fullosckey[modid][1][mask][-1])
+
+        # If none were found, this l should be skipped
+        if nmin > nmax:
             bad.append(ll)
-    for ll in bad:
-        available_lvalues.remove(ll)
+            continue
+
+        # Allocate matrix for frequencies and inertia
+        matrix = np.empty((2, nmax - nmin + 1, Ntrack))
+        matrix[:] = np.nan
+
+        freqs[ll] = matrix
+        nranges[ll] = [nmin, nmax]
+
+    # Remove bad modes
+    for mode in bad:
+        available_lvalues.remove(mode)
 
     #
-    # *** BLOCK 2: Find common values of n for each of the l values ***
+    # *** BLOCK 2: Fill out matrices ***
     #
-    # Not all models have all models available (especially in the high end). To safely
-    # interpolate, we need to locate which models each mode appears in. Takes care of
-    # modes appearing, dissapearing, and random models without the modes
-    #
-    # Stored in the array 'goodn' with same indexing syntax as the arrays above.
-    goodn = {"l=0": {}, "l=1": {}, "l=2": {}}
-    # For across we need to check the base limits doesn't change with frequency limits
-    if not along:
-        newblims = {"l=0": {}, "l=1": {}, "l=2": {}}
-    for ll in available_lvalues:
-        lkey = "l={0}".format(ll)
-        nrange = range(
-            int(np.nanmin([arr.min() if len(arr) else np.nan for arr in nvals[lkey]])),
-            int(np.nanmax([arr.max() if len(arr) else np.nan for arr in nvals[lkey]]))
-            + 1,
-        )
+    # Read in frequencies from each model into the matrices.
+    # Note that row 0 corresponds to the lowest n-value.
+    # The reading is done by l-value of each model (fewest loop
+    # iterations).
 
-        # For each n, check the following
-        for testn in nrange:
-            index = np.ones(Ntrack, dtype=bool)
-            for modid in range(Ntrack):
-                modnvals = np.asarray(nvals[lkey][modid])
-                modfvals = fvals[lkey][modid]
-                # Check if present in model
-                if testn not in modnvals:
-                    index[modid] = False
-                elif freqlims:
-                    # Check that the values are within the frequency limits
-                    modf = modfvals[np.where(modnvals == testn)[0][0]]
-                    if not (modf > freqlims[0] and modf < freqlims[1]):
-                        index[modid] = False
-
-            # Check that there are not too many missing models
-            badmode = False
-            if not sections:
-                sections = [0, -1]
-            for s in range(len(sections) - 1):
-                section = index[sections[s] : sections[s + 1]]
-                # Check that there are enough models present
-                if sum(section) <= 2:
-                    badmode = True
-                    break
-                section = section[np.where(section)[0][0] : np.where(section)[0][-1]]
-                if sum(section) / len(section) < 0.8:
-                    badmode = True
-                    break
-
-            # Append modes that passed the checks
-            if not badmode:
-                goodn[lkey][testn] = index
-            # Extract new base limits after frequency cut
-            if not badmode and not along:
-                secmins = []
-                secmaxs = []
-                for s in range(len(sections) - 1):
-                    section = agevec[:, -1][sections[s] : sections[s + 1]]
-                    secind = index[sections[s] : sections[s + 1]]
-                    secmins.append(min(section[secind]))
-                    secmaxs.append(max(section[secind]))
-                newblims[lkey][testn] = [max(secmins), min(secmaxs)]
-
-        if debug:
-            try:
-                minn = min([n for n, _ in goodn[lkey].items()])
-                maxn = max([n for n, _ in goodn[lkey].items()])
-                print("    l = {0} | n = {1:3} ... {2:3}".format(ll, minn, maxn))
-            except:
-                print("Debug print failed for _interpolate_frequencies")
-
-    #
-    # *** BLOCK 3: Interpolate in frequencies between the models ***
-    #
-    # The interpolation must be performed for each individual {l, n} seperately across
-    # all models. Frequencies and inertias are interpolated and stored in dicts, which
-    # can be indexed as e.g. newfreqs["l=0"]["n=12"].
-    newfreqs = {"l=0": {}, "l=1": {}, "l=2": {}}
-    newinert = {"l=0": {}, "l=1": {}, "l=2": {}}
-
-    # Prepare for debugging plot(s)
-    if debug:
-        debugpath = "intpolout"
-        plotpath = os.path.join(debugpath, "debug_freqs_track{0}.pdf".format(trackid))
-        if not os.path.exists(debugpath):
-            os.mkdir(debugpath)
-        if os.path.exists(plotpath):
-            skipplots = True
-        if not skipplots:
-            pdf = PdfPages(plotpath)
-
-    # Loop over l and then n
-    for ll in available_lvalues:
-        lkey = "l={0}".format(ll)
-        for nn, index in goodn[lkey].items():
-            nkey = "n={0}".format(nn)
-
-            # Extract values for a given n-value for all models
-            oldf, oldi = [], []
-            for i, ind in enumerate(index):
-                if not ind:
-                    continue
-                oldf.append(fvals[lkey][i][np.where(nvals[lkey][i] == nn)[0][0]])
-                oldi.append(ivals[lkey][i][np.where(nvals[lkey][i] == nn)[0][0]])
-
-            # Create mask to avoid extrapolation
-            if along:
-                mask = np.ones(len(newagevec), dtype=bool)
-                mask &= newagevec <= np.max(agevec[index])
-                mask &= newagevec >= np.min(agevec[index])
-            else:
-                blims = newblims[lkey][nn]
-                mask = np.ones(len(newagevec[:, -1]), dtype=bool)
-                mask &= newagevec[:, -1] <= blims[1]
-                mask &= newagevec[:, -1] >= blims[0]
-
-            # Interpolate on the same mesh as the other quantities in the main routine.
-            newf = _interpolation_wrapper(
-                agevec[index], oldf, newagevec[mask], along=along
-            )
-            newi = _interpolation_wrapper(
-                agevec[index], oldi, newagevec[mask], along=along
-            )
-            newfreqs[lkey][nkey] = newf
-            newinert[lkey][nkey] = newi
-
-            # Replace information for new vector
-            goodn[lkey][nn] = mask
-
-            # Plot the interpolated frequencies if desired
-            if not skipplots:
-                if along:
-                    xold = agevec[index]
-                    xnew = newagevec[mask]
-                else:
-                    xold = agevec[:, -1][index]
-                    xnew = newagevec[:, -1][mask]
-                _, ax = plt.subplots()
-                plt.title(
-                    "TrackID: {0}   |   l = {1}  ,  n = {2}".format(trackid, ll, nn)
-                )
-                ax.plot(
-                    xold,
-                    oldf,
-                    ".",
-                    color="#6C9D34",
-                    label="Original",
-                    alpha=0.9,
-                )
-                ax.plot(
-                    xnew,
-                    newf,
-                    ".",
-                    color="#482F76",
-                    label="Interpolated",
-                    alpha=0.5,
-                )
-                ax.set_xlabel("Base parameter")
-                ax.set_ylabel("Frequency")
-                ax.legend(loc="best", facecolor="none", edgecolor="none")
-                pdf.savefig(bbox_inches="tight")
-                plt.close()
-
-    if not skipplots:
-        pdf.close()
-    elif debug and along:
-        print("    The plot '{0}' already exist! Skipping...".format(plotpath))
-
-    #
-    # *** BLOCK 4: Pack the interpolated frequencies for grid storage ***
-    #
-    # For them to be stored in the HDF5 format, the frequencies must be restored
-    # to a per-model structure. For each point in the interpolated track, we transverse
-    # all l and then n values. They are stacked in one list per quantity and then stored
-    # as nested arrays in lists to conform to the specific format defined by the BASTA
-    # routines enabling HDF5 writing.
-    osclist = []
-    osckeylist = []
-    Nnew = len(newagevec) if along else len(newagevec[:, -1])
-    for modid in range(Nnew):
-        # Arrays corresponding to the read-out from an .obs-file (in BASTA notation)
-        lf = []
-        nf = []
-        ff = []
-        ef = []
+    for modid in range(Ntrack):
+        osc = fullosc[modid]
+        osckey = fullosckey[modid]
         for ll in available_lvalues:
-            lkey = "l={0}".format(ll)
-            modn, indmod = [], []
-            for nn, mask in goodn[lkey].items():
-                if mask[modid]:
-                    modn.append(nn)
-                    indmod.append(sum(mask[:modid]))
-            # Do not append lists, but append the elemements of the lists
-            tmp_lf = len(modn) * [ll]
-            lf = [*lf, *tmp_lf]
-            nf = [*nf, *modn]
-            ff = [
-                *ff,
-                *[newfreqs[lkey]["n={0}".format(q)][m] for q, m in zip(modn, indmod)],
-            ]
-            ef = [
-                *ef,
-                *[newinert[lkey]["n={0}".format(q)][m] for q, m in zip(modn, indmod)],
-            ]
+            nmin, _ = nranges[ll]
+            lmask = osckey[0, :] == ll
+            freqs[ll][:, osckey[1, lmask] - nmin, modid] = osc[:, lmask]
 
-        # Add the stacked ".obs-style" lists with all freq information to storage arrays
-        osckeylist.append(np.array([lf, nf], dtype=int))
-        osclist.append(np.array([ff, ef], dtype=float))
+    #
+    # *** BLOCK 3: Check for bad modes ***
+    #
+    # The source information for each mode might turn out to be too
+    # sparse. Here two checks can exclude a mode:
+    #  - A source track have 2 or fewer models with the mode
+    #  - From the first model within the track the mode appears in till
+    #    the last, 20% or more of the models does not contain the mode.
+    # A mode that fails the check will have all frequencies switched to
+    # nan's, and is thus ignored going forward.
+
+    for ll in available_lvalues:
+        matrix = freqs[ll]
+
+        # Apply frequency limits
+        mask = matrix[0] > freqlims[0]
+        mask &= matrix[0] < freqlims[1]
+
+        # Check for sections with too many missing modes
+        for nn, subm in enumerate(mask):
+            badmode = False
+            for s in range(len(sections) - 1):
+                # If already flagged, skip checking rest of sections
+                if badmode:
+                    continue
+                # Section corresponding to one enveloping track
+                section = subm[sections[s] : sections[s + 1]]
+                where = np.where(section)[0]
+                # Bad mode if not present in track
+                if len(where) <= 2:
+                    badmode = True
+                    continue
+
+                # Bad mode if 20% of models in tracks are missing mode
+                section = section[where[0] : where[-1]]
+                if bn.nansum(section) / len(section) < 0.8:
+                    badmode = True
+                    continue
+            # Flag the mode by filling with nan's
+            if badmode:
+                subm[:] = False
+
+        # Write nan's to failed models
+        matrix[0][~mask] = np.nan
+        matrix[1][~mask] = np.nan
+
+    #
+    # *** BLOCK 4: Interpolate to new frequencies ***
+    #
+    # Now we can interpolate each mode to the new track,
+    # by looping over each row in the matrices. If any source
+    # is nan, the interpolation method returns a nan, which is
+    # filled in the new matrix.
+
+    Nnew = len(newvec)
+    newfreqs = {}
+    for ll in available_lvalues:
+        matrix = freqs[ll]
+
+        # Create collection matrix
+        newmatrix = np.empty((2, matrix.shape[1], Nnew))
+        newmatrix[:] = np.nan
+
+        # Loop over both frequencies and inertia
+        for fi in range(2):
+            # Loop over n-values
+            for nn in range(matrix.shape[1]):
+                # No need if all are nan
+                if bn.allnan(matrix[fi][nn][:]):
+                    continue
+                # Interpolate !!!
+                newmatrix[fi][nn][:] = interpolation_wrapper(
+                    triangulation,
+                    matrix[fi][nn][:],
+                    newvec,
+                )
+
+        # Store new frequencies
+        newfreqs[ll] = newmatrix
+
+    #
+    # *** BLOCK 5: Pack to per-model structure ***
+    #
+    # Pack the new frequencies to the format used in the hdf5.
+    # Here the nan's are finally filtered out, as the output format
+    # is not dependent on the order of elements. If no frequencies
+    # are obtained for a model in the new track (likely due to inputted
+    # frequency limits), it will produce an empty array instead, and is
+    # thus skipped over in the fit.
+
+    osclist, osckeylist = [], []
+
+    for modid in range(Nnew):
+        osc, osckey = None, None
+        for ll in available_lvalues:
+            matrix = newfreqs[ll]
+            nmin, _ = nranges[ll]
+
+            # Construct osc for this l
+            fres = np.zeros((2, matrix.shape[1]), dtype=float)
+            fres[0][:] = matrix[0][:, modid]
+            fres[1][:] = matrix[1][:, modid]
+
+            # Construct osckeys for this l
+            keys = np.zeros((2, matrix.shape[1]), dtype=int)
+            keys[0][:] = ll
+            keys[1][:] = np.arange(matrix.shape[1]) + nmin
+
+            # Create or stack list
+            if type(osc) != np.ndarray:
+                osc = fres
+                osckey = keys
+            else:
+                osc = np.hstack((osc, fres))
+                osckey = np.hstack((osckey, keys))
+
+        # Remove nan modes
+        nanmask = np.isnan(osc[0][:])
+        osc = osc[:, ~nanmask]
+        osckey = osckey[:, ~nanmask]
+
+        osclist.append(osc)
+        osckeylist.append(osckey)
 
     return osckeylist, osclist
 
@@ -505,7 +566,7 @@ def interpolate_frequencies(
 # ======================================================================================
 # Management of header and weights
 # ======================================================================================
-def _extend_header(outfile, basepath, headvars):
+def update_header(outfile, basepath, headvars):
     """
     Rewrites the header with the information from the new tracks.
 
@@ -541,7 +602,7 @@ def _extend_header(outfile, basepath, headvars):
             values = np.zeros(ltracks)
             for _, group in outfile[basepath].items():
                 for n, (_, libitem) in enumerate(group.items()):
-                    if libitem["IntStatus"][()] != -1:
+                    if libitem["IntStatus"][()] >= 0:
                         values[n] = libitem[var][0]
             del outfile[headpath]
             outfile[headpath] = values.tolist()
@@ -665,7 +726,7 @@ def _recalculate_param_weights(outfile, basepath):
     return outfile
 
 
-def _recalculate_volume_weights(outfile, basepath, sobnums):
+def recalculate_weights(outfile, basepath, sobnums, extend=False):
     """
     Recalculates the weights of the tracks/isochrones, for the new grid.
     Tracks not transferred from old grid has IntStatus = -1.
@@ -700,6 +761,27 @@ def _recalculate_volume_weights(outfile, basepath, sobnums):
         for name, libitem in group.items():
             IntStatus.append(libitem["IntStatus"][()])
             names.append(os.path.join(gname, name))
+
+    # Reconstruct approximate Sobol numbers for original tracks
+    if extend:
+        index = np.where(np.array(IntStatus) == 1)[0]
+        bpars = outfile["header/pars_sampled"]
+        # Collect basis parameters
+        base = np.zeros((len(index), len(bpars)))
+        iter = zip(IntStatus, outfile[basepath].items())
+        for i, (ist, (_, libitem)) in enumerate(iter):
+            if ist != 1:
+                continue
+            for j, par in enumerate(bpars):
+                base[i, j] = libitem[par][0]
+
+        for i, par in enumerate(bpars):
+            mm = [min(base[:, i]), max(base[:, i])]
+            base[:, i] -= mm[0]
+            base[:, i] /= mm[1] - mm[0]
+
+        sobnum = np.vstack((base, sobnum))
+
     mask = np.where(np.array(IntStatus) >= 0)[0]
     active = np.asarray(names)[mask]
 
@@ -746,3 +828,62 @@ def _recalculate_volume_weights(outfile, basepath, sobnums):
     outfile["header/active_weights"] = ["volume"]
 
     return outfile
+
+
+# ======================================================================================
+# Miscellaneous helper functions
+# ======================================================================================
+def lowest_l0(grid, basepath, track, selmod):
+    """
+    Determine the lowest n of l=0 frequency modes present along the whole track.
+
+    Parameters
+    ----------
+    grid : hdf5 file
+        Inputted grid
+    basepath : str
+        Path in the grid where the tracks are stored.
+    track : str
+        The track to extract from.
+    selmod : boolean numpy array
+        The selected models within the track to consider
+
+    Returns
+    -------
+    maxofmin : int
+        Lowest n of mode present in all models
+    """
+    keypath = os.path.join(basepath, track, "osckey")
+    min_n_l0 = np.zeros((sum(selmod)))
+    for i, osckey in enumerate(grid[keypath][()][selmod]):
+        min_n_l0[i] = min(osckey[1][osckey[0] == 0])
+    maxofmin = max(min_n_l0)
+    return maxofmin
+
+
+def get_l0_freqs(track, selmod, N):
+    """
+    Extract the frequency along the track of the given (n=N,l=0)
+    frequency mode.
+
+    Parameters
+    ----------
+    track : hdf5 group
+        All data of the track being processed
+    selmod : boolean numpy array
+        The selected models within the track to consider
+    N : int
+        Lowest n of mode present in all models across enveloping tracks
+
+    Returns
+    -------
+    freqs : numpy array
+        Frequencies of the given mode along the track
+    """
+    allkeys = track["osckey"][()][selmod]
+    alloscs = track["osc"][()][selmod]
+    freqs = np.zeros((sum(selmod)))
+    for i, (key, osc) in enumerate(zip(allkeys, alloscs)):
+        ind = np.where(key[1][key[0] == 0] == N)[0]
+        freqs[i] = osc[0][key[0] == 0][ind]
+    return freqs

--- a/basta/plot_seismic.py
+++ b/basta/plot_seismic.py
@@ -654,6 +654,10 @@ def epsilon_difference_diagram(
         sequence,
     )
 
+    # Mixed modes results in negative differences. Flag using nans, not displayed
+    mask = np.where(modepsdiff[0, :] < 0)[0]
+    modepsdiff[0, mask] = np.nan
+
     fig, ax = plt.subplots(1, 1)
     handles, legends = [], []
     for ll in l_available:

--- a/basta/stats.py
+++ b/basta/stats.py
@@ -316,6 +316,10 @@ def chi2_astero(
             nsorting=fitfreqs["nsorting"],
         )
 
+        # Mixed modes results in negative differences. Flag using nans
+        mask = np.where(modepsdiff[0, :] < 0)[0]
+        modepsdiff[0, mask] = np.nan
+
         # Interpolate model epsdiff to the frequencies of the observations
         evalepsdiff = np.zeros(obsepsdiff.shape[1])
         evalepsdiff[:] = np.nan

--- a/basta/utils_xml.py
+++ b/basta/utils_xml.py
@@ -140,7 +140,6 @@ def create_xmltag(
 
     # Handle interpolation parameters (special treatment of dnu; not add if added)
     for param in intpollim:
-        print(param)
         out = {}
         gparam = "dnu" if "dnu" in param else param
         nucheck = not nuset[gparam] if gparam in nuset else False

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -815,7 +815,6 @@ def run_xml(
                         allintpol[starid],
                         inputparams,
                         debug=debug,
-                        verbose=verbose,
                     )
             except KeyboardInterrupt:
                 print("BASTA interpolation stopped manually. Goodbye!")

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -240,6 +240,7 @@ def _get_intpol(root, gridfile, freqpath=None):
             intpol[param.tag.lower()] = {
                 "case": param.attrib.get("case"),
                 "construction": param.attrib.get("construction"),
+                "retrace": strtobool(param.attrib.get("retrace", "False")),
             }
         else:
             raise ValueError(
@@ -254,6 +255,13 @@ def _get_intpol(root, gridfile, freqpath=None):
         raise ValueError(
             "Unknown construction method selected. Must be either 'bystar' or 'encompass'!"
         )
+
+    # Permeate retrace option
+    if intpol["method"]["retrace"]:
+        if "trackresolution" in intpol:
+            intpol["trackresolution"]["retrace"] = True
+        if "gridresolution" in intpol:
+            intpol["gridresolution"]["retrace"] = True
 
     # If interpolation in frequencies requested, extract limits
     freqnames = ["freq", "freqs", "frequency", "frequencies", "osc"]

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -172,8 +172,8 @@ def _get_freq_minmax(star, freqpath):
     freqfile = os.path.join(freqpath, star.get("starid") + ".xml")
     f, _, _, _ = read_freqs_xml(freqfile)
     dnu = float(star.find("dnu").get("value"))
-    fmin = f.min() - 0.5 * dnu
-    fmax = f.max() + 0.5 * dnu
+    fmin = f.min() - 2.0 * dnu
+    fmax = f.max() + 2.0 * dnu
     return fmin, fmax
 
 
@@ -230,6 +230,7 @@ def _get_intpol(root, gridfile, freqpath=None):
                 "eta": int(param.attrib.get("eta", 0.0)),
                 "scale": float(param.attrib.get("scale", 0.0)),
                 "baseparam": param.attrib.get("baseparam", "xcen"),
+                "extend": strtobool(param.attrib.get("extend", "False")),
             }
         elif param.tag.lower() == "name":
             intpol[param.tag.lower()] = {


### PR DESCRIPTION
Implemented new one-step combined interpolation method and purged the old (across-along and along-across). 
Added new and more efficient frequency interpolation method, removed old.
Added sophisticated choice of base along a track, given the resolution of enveloping/original track, mimicing the distribution instead of equidistant spacing in the base parameter.
Implemented and cleaned the "Extend" option, to keep old tracks when interpolating across. It is added under the "gridresolution" controls.
Added a "retrace" option to interpolation, which saves a record for each model of which models were used as sources in the interpolation, and the corresponding weights of these. It is added under the "method" controls.
Added WIP tratment of mixed-mode models when fitting epsilon differences.
