### PR TITLE
Name in plots

### DIFF
--- a/basta/bastamain.py
+++ b/basta/bastamain.py
@@ -849,6 +849,7 @@ def BASTA(
             path=maxPDF_path,
             ind=maxPDF_ind,
             plotfname=outfilename + "_{0}." + inputparams["plotfmt"],
+            nameinplot=inputparams["nameinplot"],
             **addstats,
             debug=debug,
         )

--- a/basta/plot_corner.py
+++ b/basta/plot_corner.py
@@ -53,6 +53,7 @@ def corner(
     uncert="quantiles",
     kde_points=250,
     kde_method="silverman",
+    nameinplot=False,
     **hist2d_kwargs,
 ):
     """
@@ -146,6 +147,9 @@ def corner(
     kde_method : str, optional
         Method used to select the bandwidth in the gaussian KDE. Passed directly to
         the routine in SciPy. Default is Scott's rule.
+
+    nameinplot : str, bool
+        Star identifier if it is to be included in the figure.
 
     **hist2d_kwargs, optional
         Any remaining keyword arguments are sent to `corner.hist2d` to generate
@@ -377,6 +381,8 @@ def corner(
                 ax.set_frame_on(False)
                 ax.set_xticks([])
                 ax.set_yticks([])
+                if j == K - 1 and i == 0:
+                    ax.set_title(nameinplot if nameinplot else "")
                 continue
             elif j == i:
                 continue

--- a/basta/plot_driver.py
+++ b/basta/plot_driver.py
@@ -18,6 +18,7 @@ def plot_all_seismic(
     path,
     ind,
     plotfname,
+    nameinplot=False,
     dnusurf=None,
     glitchparams=None,
     debug=False,
@@ -59,6 +60,8 @@ def plot_all_seismic(
         Index of the highest likelihood model in the track
     plotfname : str
         Output plotname format
+    nameinplot : bool
+        Whether to include star identifier in the plots itself
     debug : bool
         Whether to produce debugging output
 

--- a/basta/plot_kiel.py
+++ b/basta/plot_kiel.py
@@ -102,6 +102,7 @@ def kiel(
     Teffout,
     loggout,
     gridtype,
+    nameinplot=False,
     debug=False,
     experimental=False,
     validationmode=False,
@@ -144,6 +145,8 @@ def kiel(
     gridtype : str
         Type of the grid (as read from the grid in bastamain) containing either 'tracks'
         or 'isochrones'.
+    nameinplot : str or bool
+        Star identifier if it is to be included in the figure
     debug : bool, optional
         Debug flag.
     experimental : bool, optional
@@ -508,6 +511,7 @@ def kiel(
             ncol=ncol,
             mode="expand",
             borderaxespad=0.0,
+            title=nameinplot if nameinplot else "",
         )
         _, axlabels, _, _ = parameters.get_keys(["Teff", "logg"])
         ax.set_xlabel(axlabels[0])

--- a/basta/process_output.py
+++ b/basta/process_output.py
@@ -499,6 +499,7 @@ def compute_posterior(
                         Teffout=Teffout,
                         loggout=loggout,
                         gridtype=gridtype,
+                        nameinplot=starid if inputparams["nameinplot"] else False,
                         debug=debug,
                         experimental=experimental,
                         validationmode=validationmode,
@@ -519,6 +520,7 @@ def compute_posterior(
                 truth_color=parameters.get_keys(cornerplots)[3],
                 plotin=plotin,
                 plotout=plotout,
+                nameinplot=starid if inputparams["nameinplot"] else False,
                 **ckwargs,
             )
             cornerfile = outfilename + "_corner." + plottype
@@ -535,6 +537,7 @@ def compute_posterior(
                     truth_color=parameters.get_keys(cornerplots)[3],
                     plotin=plotin,
                     plotout=plotout,
+                    nameinplot=starid if inputparams["nameinplot"] else False,
                     **ckwargs,
                 )
                 cornerfile = outfilename + "_DEBUG_likelihood_corner." + plottype
@@ -550,6 +553,7 @@ def compute_posterior(
                     truth_color=parameters.get_keys(cornerplots)[3],
                     plotin=plotin,
                     plotout=plotout,
+                    nameinplot=starid if inputparams["nameinplot"] else False,
                     **ckwargs,
                 )
                 cornerfile = outfilename + "_DEBUG_prior_corner." + plottype
@@ -592,6 +596,7 @@ def compute_posterior(
                 Teffout=Teffout,
                 loggout=loggout,
                 gridtype=gridtype,
+                nameinplot=starid if inputparams["nameinplot"] else False,
                 debug=debug,
                 experimental=experimental,
                 validationmode=validationmode,

--- a/basta/xml_create.py
+++ b/basta/xml_create.py
@@ -24,6 +24,7 @@ def generate_xml(
     centroid=None,
     uncert=None,
     plotfmt=None,
+    nameinplot=False,
     odea=None,
     intpolparams=None,
     bayweights=True,
@@ -86,6 +87,9 @@ def generate_xml(
         Format of outputted plots, simply given directly to pyplot.savefig.
         Default is 'png' for quick figures. For detailed plots, 'pdf' is
         recommended.
+    nameinplot : bool
+        Toggle to include star identifier in plots, not simply in filename
+        of plot.
     odea : tuple or None
         Specifies the input physics used to compute the grid.
         `o` : overshoot efficiency, 0.0 = no overshoot.
@@ -198,6 +202,10 @@ def generate_xml(
     # Add plotformat to <default> if user provided
     if plotfmt is not None:
         SubElement(default, "plotfmt", {"value": str(plotfmt)})
+
+    # Add nameinplot to <default> if set by user
+    if nameinplot:
+        SubElement(default, "nameinplot", {"value": "True"})
 
     # Add ove, eta, diffusion and alphaFe to <basti> if isochrone
     if odea:

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -473,6 +473,11 @@ def run_xml(
     # Format of outputted plots, default png for speed, pdf for vector art
     inputparams["plotfmt"] = _find_get(root, "default/plotfmt", "value", "png")
 
+    # Switch to include star identifier in plots, not just in filename, False is default
+    inputparams["nameinplot"] = strtobool(
+        _find_get(root, "default/nameinplot", "value", "False")
+    )
+
     # Path for science-cases in isochrones, only active for that case
     bastiparams = root.find("default/basti")
     if bastiparams:

--- a/docs/controls_outplots.rst
+++ b/docs/controls_outplots.rst
@@ -141,3 +141,15 @@ small format, so preferable when creating many figures/fitting multiple stars.
 However, if high resolution/vector graphics is desirable, ``pdf`` is recommended.
 Otherwise, it can be any file format compatible with
 `matplotlib.pyplot.savefig <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html>`_.
+
+
+Star identifier in plots
+------------------------
+.. code-block:: python
+
+    define_plots["nameinplot"] = True
+
+The star identifier is normally only contained in the name of plot files.
+However, depending on the preferred post-processing procedure of the user,
+it can be beneficial to include in the plots itself, which can be turned
+on using this key. Currently, only implemented for Kiel diagram and corner plots.

--- a/examples/create_inputfile.py
+++ b/examples/create_inputfile.py
@@ -391,6 +391,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     # define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_distance.py
+++ b/examples/xmlinput/create_inputfile_distance.py
@@ -409,6 +409,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_epsilondifference.py
+++ b/examples/xmlinput/create_inputfile_epsilondifference.py
@@ -401,6 +401,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_freqs.py
+++ b/examples/xmlinput/create_inputfile_freqs.py
@@ -400,6 +400,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_glitches.py
+++ b/examples/xmlinput/create_inputfile_glitches.py
@@ -404,6 +404,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_global.py
+++ b/examples/xmlinput/create_inputfile_global.py
@@ -401,6 +401,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_interp_MS.py
+++ b/examples/xmlinput/create_inputfile_interp_MS.py
@@ -401,6 +401,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_json.py
+++ b/examples/xmlinput/create_inputfile_json.py
@@ -401,6 +401,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_parallax.py
+++ b/examples/xmlinput/create_inputfile_parallax.py
@@ -409,6 +409,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_phase.py
+++ b/examples/xmlinput/create_inputfile_phase.py
@@ -410,6 +410,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_ratios.py
+++ b/examples/xmlinput/create_inputfile_ratios.py
@@ -401,6 +401,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================

--- a/examples/xmlinput/create_inputfile_subgiant.py
+++ b/examples/xmlinput/create_inputfile_subgiant.py
@@ -397,6 +397,12 @@ def define_input(define_io, define_fit, define_output, define_plots, define_intp
     # usually preferred.
     define_plots["plotfmt"] = "pdf"
 
+    # The star identifier is normally only contained in the name of plot files.
+    # However, depending on the preferred post-processing procedure of the user,
+    # it can be beneficial to include in the plots itself, which can be turned
+    # on using this key.
+    # define_plots["nameinplot"] = True
+
     # ==================================================================================
     # BLOCK 5: Interpolation
     # ==================================================================================


### PR DESCRIPTION
Added the "nameinplot" toggle to include the star identifier (starid) to: 

- The Kiel diagram above the legend
- The corner plot in the top right corner

By default turned off, simply toggle to true to enable.