### PR TITLE
Distance fixes

### DIFF
--- a/basta/distances.py
+++ b/basta/distances.py
@@ -58,16 +58,7 @@ def LOS_reddening(distanceparams):
        excess color function
     """
     if "EBV" in distanceparams:
-        return lambda x: np.asarray(
-            np.random.normal(
-                distanceparams["EBV"][0],
-                distanceparams["EBV"][2] - distanceparams["EBV"][0],
-                size=[
-                    len(i) if isinstance(i, collections.abc.Iterable) else 1
-                    for i in [x]
-                ][0],
-            )
-        )
+        return lambda x: np.ones(len(x)) * distanceparams["EBV"][1]
 
     frame = distanceparams["dustframe"]
 
@@ -404,7 +395,7 @@ def add_absolute_magnitudes(
     # Get an estimate from all filters
     labsms_joined = np.exp(llabsms_joined - np.log(np.sum(np.exp(llabsms_joined))))
 
-    distanceparams["EBV"] = list(
+    distanceparams["priorEBV"] = list(
         stats.quantile_1D(EBVs, labsms_joined, cnsts.statdata.quantiles)
     )
     distanceparams["priordistance"] = list(

--- a/basta/plot_corner.py
+++ b/basta/plot_corner.py
@@ -274,23 +274,29 @@ def corner(
                 n = gaussian_filter(n, smooth1d)
                 x0 = np.array(list(zip(b[:-1], b[1:]))).flatten()
                 y0 = np.array(list(zip(n, n))).flatten()
+                ax.plot(x0, y0, **hist_kwargs)
+                ax.fill_between(
+                    x0, y0, y2=-1, interpolate=True, color=tcolor, alpha=0.15
+                )
             else:
                 try:
                     kernel = gaussian_kde(x, bw_method=kde_method)
+                    x0 = np.linspace(np.amin(x), np.amax(x), num=kde_points)
+                    y0 = kernel(x0)
+                    y0 /= np.amax(y0)
+                    n = gaussian_filter(n, 1)
+                    ax.plot(x0, y0, **hist_kwargs)
+                    ax.fill_between(
+                        x0, y0, y2=-1, interpolate=True, color=tcolor, alpha=0.15
+                    )
                 except np.linalg.LinAlgError:
-                    print("WARNING! Unable to create KDE. Skipping plot...")
-                    raise
-                x0 = np.linspace(np.amin(x), np.amax(x), num=kde_points)
-                y0 = kernel(x0)
-                y0 /= np.amax(y0)
-                n = gaussian_filter(n, 1)
-                x0_hist = np.array(list(zip(b[:-1], b[1:]))).flatten()
-                y0_hist = np.array(list(zip(n, n))).flatten() / np.amax(n)
-                ax.fill_between(
-                    x0_hist, y0_hist, y2=-1, interpolate=True, color=tcolor, alpha=0.15
-                )
-            ax.plot(x0, y0, **hist_kwargs)
-            ax.fill_between(x0, y0, y2=-1, interpolate=True, color=tcolor, alpha=0.15)
+                    print("WARNING! Unable to create a KDE...")
+
+            x0_hist = np.array(list(zip(b[:-1], b[1:]))).flatten()
+            y0_hist = np.array(list(zip(n, n))).flatten() / np.amax(n)
+            ax.fill_between(
+                x0_hist, y0_hist, y2=-1, interpolate=True, color=tcolor, alpha=0.15
+            )
 
         # Plot quantiles
         q = plotout[3 * i]
@@ -656,8 +662,8 @@ def hist2d(
             contour_kwargs["colors"] = contour_kwargs.get("colors", color)
             ax.contour(X2, Y2, H2.T, V, **contour_kwargs)
 
-    ax.set_xlim(prange[0])
-    ax.set_ylim(prange[1])
+        ax.set_xlim(prange[0])
+        ax.set_ylim(prange[1])
 
 
 def lighten_color(color, amount=0.5):

--- a/basta/plot_corner.py
+++ b/basta/plot_corner.py
@@ -163,6 +163,11 @@ def corner(
     if label_kwargs is None:
         label_kwargs = {}
 
+    formatter = ScalarFormatter()
+    formatter.set_scientific("%.2e")
+    formatter.set_useMathText(True)
+    formatter.set_powerlimits((-2, 4))
+
     # Deal with 1D sample lists.
     xs = np.atleast_1d(xs)
     if len(xs.shape) == 1:
@@ -373,7 +378,7 @@ def corner(
                     ax.xaxis.set_label_coords(0.5, -0.35)
 
             # use MathText for axes ticks
-            ax.xaxis.set_major_formatter(ScalarFormatter(useMathText=use_math_text))
+            ax.xaxis.set_major_formatter(formatter)
 
         for j, y in enumerate(xs):
             if np.shape(xs)[0] == 1:
@@ -434,7 +439,7 @@ def corner(
                         ax.xaxis.set_label_coords(0.5, -0.35)
 
                 # use MathText for axes ticks
-                ax.xaxis.set_major_formatter(ScalarFormatter(useMathText=use_math_text))
+                ax.xaxis.set_major_formatter(formatter)
 
             if j > 0:
                 ax.set_yticklabels([])
@@ -451,7 +456,7 @@ def corner(
                         ax.yaxis.set_label_coords(-0.35, 0.5)
 
                 # use MathText for axes ticks
-                ax.yaxis.set_major_formatter(ScalarFormatter(useMathText=use_math_text))
+                ax.yaxis.set_major_formatter(formatter)
 
     return fig
 
@@ -662,7 +667,10 @@ def hist2d(
             contour_kwargs["colors"] = contour_kwargs.get("colors", color)
             ax.contour(X2, Y2, H2.T, V, **contour_kwargs)
 
+    # Set axis limits if plotting dimension
+    if not np.all(x == x[0]):
         ax.set_xlim(prange[0])
+    if not np.all(y == y[0]):
         ax.set_ylim(prange[1])
 
 

--- a/basta/process_output.py
+++ b/basta/process_output.py
@@ -201,7 +201,7 @@ def compute_posterior(
             )
 
             d_samples[:, j] = d_all[nonzeroprop][sampled_indices]
-            d_samples[:, j + 1] = EBV_all[nonzeroprop][sampled_indices]
+            d_samples[:, j + 1] = A_all[nonzeroprop][sampled_indices]
             j += 2
 
         # Compute joint distance and extinction posteriors

--- a/basta/utils_xml.py
+++ b/basta/utils_xml.py
@@ -105,19 +105,6 @@ def create_xmltag(
         if not np.isclose(paramval, missingval):
             SubElement(star, param, {"value": str(paramval)})
 
-    # Check if extinction is provided for distance fit
-    # If provided with no error, error is zero
-    if len(distparams) and "EBV" in params:
-        EBVval = _get_param(paramvals, params, "EBV")
-        if "EBV_err" in params:
-            EBVerr = _get_param(paramvals, params, "EBV_err")
-            if np.isclose(EBVerr, missingval):
-                EBVerr = 0
-        else:
-            EBVerr = 0
-        if not np.isclose(EBVval, missingval):
-            SubElement(star, "EBV", {"value": str(EBVval), "error": str(EBVerr)})
-
     # Handle the special things for frequency fitting
     if freqparams and any(x in fitparams for x in freqtypes.alltypes):
         fps = np.asarray(["excludemodes", "nottrustedfile"])

--- a/basta/utils_xml.py
+++ b/basta/utils_xml.py
@@ -102,8 +102,21 @@ def create_xmltag(
     # Handle additional parameters (without errors)
     for param in distparams:
         paramval = _get_param(paramvals, params, param)
-        if not np.isclose(paramerr, missingval):
+        if not np.isclose(paramval, missingval):
             SubElement(star, param, {"value": str(paramval)})
+
+    # Check if extinction is provided for distance fit
+    # If provided with no error, error is zero
+    if len(distparams) and "EBV" in params:
+        EBVval = _get_param(paramvals, params, "EBV")
+        if "EBV_err" in params:
+            EBVerr = _get_param(paramvals, params, "EBV_err")
+            if np.isclose(EBVerr, missingval):
+                EBVerr = 0
+        else:
+            EBVerr = 0
+        if not np.isclose(EBVval, missingval):
+            SubElement(star, "EBV", {"value": str(EBVval), "error": str(EBVerr)})
 
     # Handle the special things for frequency fitting
     if freqparams and any(x in fitparams for x in freqtypes.alltypes):

--- a/basta/xml_create.py
+++ b/basta/xml_create.py
@@ -346,6 +346,10 @@ def generate_xml(
             print("Illegal dustframe specified! Not adding coordinates.")
             distparams = ()
 
+        # If EBV is supplied, read for each star
+        if "EBV" in params:
+            distparams += ("EBV",)
+
         # Add magnitudes to list of parameters
         starparams = fitparams + filters
     else:

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -829,15 +829,12 @@ def run_xml(
                 # Load extinction or use dustmap
                 EBV = star.find("EBV")
                 if EBV is not None:
-                    val, err = float(EBV.get("value")), float(EBV.get("error"))
-                    distanceparams["EBV"] = [min(val - err, 0), val, val + err]
-                    distanceparams["dustframe"] = _find_get(
-                        root, "default/distanceInput/dustframe", "value"
-                    )
-                else:
-                    distanceparams["dustframe"] = _find_get(
-                        root, "default/distanceInput/dustframe", "value"
-                    )
+                    val = float(EBV.get("value"))
+                    distanceparams["EBV"] = [val, val, val]
+
+                distanceparams["dustframe"] = _find_get(
+                    root, "default/distanceInput/dustframe", "value"
+                )
 
                 # Find available filters and load corresponding magnitudes
                 distanceparams["filters"] = []

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -830,7 +830,7 @@ def run_xml(
                 EBV = star.find("EBV")
                 if EBV is not None:
                     val = float(EBV.get("value"))
-                    distanceparams["EBV"] = [val, val, val]
+                    distanceparams["EBV"] = [0, val, 0]
 
                 distanceparams["dustframe"] = _find_get(
                     root, "default/distanceInput/dustframe", "value"


### PR DESCRIPTION
Multiple fixes related to extinctions, E(B-V), when fitting distances:

- Fixing issue #49. Provided extinction value is now read from ascii file for each star.
- If extinction is provided, assume the exact value, instead of randomly sampling a single value from a normal distribution.
- Correctly extracts and plots the extinction value in the `*starid*_distance_corner` plot.

Additionally, where corner plots would previously be skipped entirely if a single KDE of the posterior could not be formed, it will now simply skip that KDE, but produce the rest of the plot.