### PR TITLE
Bug fixes for numpy & distutils

### DIFF
--- a/basta/constants.py
+++ b/basta/constants.py
@@ -1,6 +1,7 @@
 """
 Collection of all constants used in BASTA
 """
+
 from dataclasses import dataclass  # Python 3.7+ !
 import numpy as np
 
@@ -472,7 +473,7 @@ class extinction:
             ("Mw2_WISE", 0.15, 0.15, 0, 0, 0),
         ],
         dtype=[
-            ("Filter", np.unicode_, 16),
+            ("Filter", np.str_, 16),
             ("RZ_mean", float),
             ("a0", float),
             ("a1", float),

--- a/basta/plot_seismic.py
+++ b/basta/plot_seismic.py
@@ -1,6 +1,7 @@
 """
 Production of asteroseismic plots
 """
+
 import os
 import numpy as np
 import matplotlib
@@ -268,7 +269,7 @@ def echelle(
                     linewidths=1,
                     edgecolors="k",
                     zorder=3,
-                    label=f"Best fit $\ell={l}$",
+                    label=f"Best fit $\\ell={l}$",
                 )
                 if duplicate:
                     ax.scatter(
@@ -289,7 +290,7 @@ def echelle(
                     mfc=colors["l" + l],
                     ecolor=colors["l" + l],
                     zorder=1,
-                    label=f"Measured $\ell={l}$",
+                    label=f"Measured $\\ell={l}$",
                 )
                 if duplicate:
                     ax.errorbar(

--- a/basta/stats.py
+++ b/basta/stats.py
@@ -1,13 +1,13 @@
 """
 Key statistics functions
 """
+
 import os
 import copy
 import math
 import collections
 
 import numpy as np
-from numpy.lib.histograms import _hist_bin_fd
 from scipy.interpolate import interp1d, CubicSpline
 from scipy.ndimage.filters import gaussian_filter1d
 
@@ -21,6 +21,36 @@ Trackstats = collections.namedtuple("Trackstats", "index logPDF chi2")
 priorlogPDF = collections.namedtuple("Trackstats", "index logPDF chi2 bayw magw IMFw")
 Trackdnusurf = collections.namedtuple("Trackdnusurf", "dnusurf")
 Trackglitchpar = collections.namedtuple("Trackglitchpar", "AHe dHe tauHe")
+
+
+def _hist_bin_fd(x, range):
+    """
+    The Freedman-Diaconis histogram bin estimator.
+
+    The Freedman-Diaconis rule uses interquartile range (IQR) to
+    estimate binwidth. It is considered a variation of the Scott rule
+    with more robustness as the IQR is less affected by outliers than
+    the standard deviation. However, the IQR depends on fewer points
+    than the standard deviation, so it is less accurate, especially for
+    long tailed distributions.
+
+    If the IQR is 0, this function returns 0 for the bin width.
+    Binwidth is inversely proportional to the cube root of data size
+    (asymptotically optimal).
+
+    Parameters
+    ----------
+    x : array_like
+        Input data that is to be histogrammed, trimmed to range. May not
+        be empty.
+
+    Returns
+    -------
+    h : An estimate of the optimal bin width for the given data.
+    """
+    del range  # unused
+    iqr = np.subtract(*np.percentile(x, [75, 25]))
+    return 2.0 * iqr * x.size ** (-1.0 / 3.0)
 
 
 def _weight(N, seisw):

--- a/basta/utils_general.py
+++ b/basta/utils_general.py
@@ -1,6 +1,7 @@
 """
 General mix of utility functions
 """
+
 import sys
 from io import IOBase
 
@@ -363,3 +364,25 @@ def printparam(param, xmed, xstdm, xstdp, uncert="quantiles", centroid="median")
     else:
         print("{0:9}  {1:13} :  {2:12.6f}".format("stdev", param, xstdm))
     print("-----------------------------------------------------")
+
+
+def strtobool(val):
+    """
+    Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'.
+    False values are 'n', 'no', 'f', 'false', 'off', and '0'.
+
+    Raises ValueError if 'val' is anything else.
+
+    Parameter
+    ---------
+    val: str
+        String value to be converted into a boolean.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/basta/utils_seismic.py
+++ b/basta/utils_seismic.py
@@ -1,10 +1,10 @@
 """
 Auxiliary functions for frequency analysis
 """
+
 from math import frexp
 import os
 from copy import deepcopy
-from distutils.util import strtobool
 from tqdm import tqdm
 
 import numpy as np
@@ -15,6 +15,7 @@ from basta import glitch_fit
 from basta import fileio as fio
 from basta.constants import sydsun as sydc
 from basta.constants import freqtypes
+from basta.utils_general import strtobool
 
 from sklearn import covariance as skcov
 

--- a/basta/utils_xml.py
+++ b/basta/utils_xml.py
@@ -1,6 +1,7 @@
 """
 Utilities for handling of XML files
 """
+
 from builtins import str
 from xml.dom import minidom
 from xml.etree.ElementTree import Element, SubElement, tostring
@@ -88,7 +89,7 @@ def create_xmltag(
         paramval = _get_param(paramvals, params, param)
         if isinstance(paramval, np.str_) and paramval != missingval:
             SubElement(star, param, {"value": str(paramval)})
-        if (not isinstance(paramval, np.unicode_)) and (
+        if (not isinstance(paramval, np.str_)) and (
             not np.isclose(paramval, missingval)
         ):
             paramerr = _get_param(paramvals, params, param + "_err")

--- a/basta/xml_run.py
+++ b/basta/xml_run.py
@@ -1,6 +1,7 @@
 """
 Running BASTA from XML files. Main wrapper!
 """
+
 import os
 import gc
 import sys
@@ -8,7 +9,6 @@ import copy
 import h5py
 import traceback
 from xml.etree import ElementTree
-from distutils.util import strtobool
 
 import numpy as np
 
@@ -18,7 +18,7 @@ from basta.constants import parameters
 from basta.constants import freqtypes
 from basta.fileio import no_models, read_freq_xml, write_star_to_errfile
 from basta.utils_xml import ascii_to_xml
-from basta.utils_general import unique_unsort
+from basta.utils_general import strtobool, unique_unsort
 from basta.interpolation_driver import perform_interpolation
 
 
@@ -676,11 +676,14 @@ def run_xml(
 
     # First, delete any existing file, then open file for appending
     # --> This is essential when running on multiple stars
-    with open(asciifilepath, "wb"), open(asciifilepath, "ab+") as fout, open(
-        errfilepath, "w"
-    ), open(errfilepath, "a+") as ferr, open(warnfilepath, "w"), open(
-        warnfilepath, "a+"
-    ) as fwarn:
+    with (
+        open(asciifilepath, "wb"),
+        open(asciifilepath, "ab+") as fout,
+        open(errfilepath, "w"),
+        open(errfilepath, "a+") as ferr,
+        open(warnfilepath, "w"),
+        open(warnfilepath, "a+") as fwarn,
+    ):
         inputparams["asciioutput"] = fout
         inputparams["erroutput"] = ferr
         inputparams["warnoutput"] = fwarn


### PR DESCRIPTION
BASTA currently fails to run on Python 3.12.3 when following the documentation. 

Cloning the BASTA repo, setting up a virtual environement, then following the instructions at https://basta.readthedocs.io/en/latest/running.html fails for the following reasons:

- `No module named 'disutils'`
- `np.unicode_ was removed in the NumPy 2.0 release. Use np.str_ instead`
-  `No module named 'numpy.histogram'`

and the following warning:

- `\e isn't a valid escape`

`disutils` was used to import the strtobool function. A copy of this function has been added to utils_general.py and is used instead.

`np.unicode_` has been changed to `np.str_` as advised by Numpy.

`numpy.histogram` was used to access the private function _hist_bin_fd which is deprecated by numpy. This function has been coped into the codebase directly instead. This might not be the best way to address this error. Changing the code to allow numpy to automate this calculation with something like `hist, bin_edges = np.histogram(data, bins="fd")` might be more maintainable but hasn't been implemented due to my lack of knowledge about the science requirements.

`label=f"Best fit $\ell={l}$",` code causes a warning error about improperly escaped characters. This has been changed to label=f"Best fit $\\ell={l}$" which fixes the warning but might cause other issues I'm not aware of. This PR should be rejected if this is the case and I'll remove this part of the PR and submit again.

